### PR TITLE
Tests for bridge methods

### DIFF
--- a/gosu-test/src/main/java/gw/specification/interfaces/ClassC.java
+++ b/gosu-test/src/main/java/gw/specification/interfaces/ClassC.java
@@ -1,0 +1,4 @@
+package gw.specification.interfaces;
+
+public abstract class ClassC implements InterfaceB {
+}

--- a/gosu-test/src/main/java/gw/specification/interfaces/InterfaceA.java
+++ b/gosu-test/src/main/java/gw/specification/interfaces/InterfaceA.java
@@ -1,0 +1,5 @@
+package gw.specification.interfaces;
+
+public interface InterfaceA<T extends Number> {
+  T getValue();
+}

--- a/gosu-test/src/main/java/gw/specification/interfaces/InterfaceB.java
+++ b/gosu-test/src/main/java/gw/specification/interfaces/InterfaceB.java
@@ -1,0 +1,4 @@
+package gw.specification.interfaces;
+
+public interface InterfaceB extends InterfaceA<Long> {
+}

--- a/gosu-test/src/main/java/gw/specification/interfaces/InterfaceD.java
+++ b/gosu-test/src/main/java/gw/specification/interfaces/InterfaceD.java
@@ -1,0 +1,7 @@
+package gw.specification.interfaces;
+
+import java.io.Serializable;
+
+public interface InterfaceD {
+  Serializable getValue();
+}

--- a/gosu-test/src/test/gosu/gw/specification/interfaces/BridgeMethodsTest.gs
+++ b/gosu-test/src/test/gosu/gw/specification/interfaces/BridgeMethodsTest.gs
@@ -1,0 +1,31 @@
+package gw.specification.interfaces
+
+uses gw.BaseVerifyErrantTest
+
+class BridgeMethodsTest extends BaseVerifyErrantTest {
+  function testBridgeMethodsInterface() {
+    var x = new ImplementsInterface()
+
+    assertEquals(123, x.Value)
+    var a : InterfaceA<java.lang.Long> = x
+    assertEquals(123, a.Value)
+    var b : InterfaceB = x
+    assertEquals(123, b.Value)
+    var d : InterfaceD = x
+    assertEquals(123, d.Value)
+  }
+
+  function testBridgeMethodsClass() {
+    var x = new ExtendsClass()
+
+    assertEquals(123, x.Value)
+    var a : InterfaceA<java.lang.Long> = x
+    assertEquals(123, a.Value)
+    var b : InterfaceB = x
+    assertEquals(123, b.Value)
+    var c : ClassC = x
+    assertEquals(123, c.Value)
+    var d : InterfaceD = x
+    assertEquals(123, d.Value)
+  }
+}

--- a/gosu-test/src/test/gosu/gw/specification/interfaces/ExtendsClass.gs
+++ b/gosu-test/src/test/gosu/gw/specification/interfaces/ExtendsClass.gs
@@ -1,0 +1,8 @@
+package gw.specification.interfaces
+
+class ExtendsClass extends ClassC implements InterfaceD {
+
+  property get Value(): java.lang.Long {
+    return 123
+  }
+}

--- a/gosu-test/src/test/gosu/gw/specification/interfaces/ImplementsInterface.gs
+++ b/gosu-test/src/test/gosu/gw/specification/interfaces/ImplementsInterface.gs
@@ -1,0 +1,8 @@
+package gw.specification.interfaces
+
+class ImplementsInterface implements InterfaceB, InterfaceD {
+
+  property get Value(): java.lang.Long {
+    return 123
+  }
+}


### PR DESCRIPTION
Gosu fails to generate bridge methods in certain cases.
Created set of tests to reproduce the issue.

Note that issue still exist in Java 8 branch in certain scenarios (see tests).
