### PR TITLE
Gosu should honor @SimpleAnnotationProcessing for field properties

### DIFF
--- a/gosu-core/src/main/java/gw/internal/gosu/parser/JavaFieldPropertyInfo.java
+++ b/gosu-core/src/main/java/gw/internal/gosu/parser/JavaFieldPropertyInfo.java
@@ -55,7 +55,7 @@ public class JavaFieldPropertyInfo extends JavaBaseFeatureInfo implements IJavaF
     }
   };
 
-  JavaFieldPropertyInfo(IFeatureInfo container, IType type, IJavaClassField field, boolean isStatic)
+  JavaFieldPropertyInfo(IFeatureInfo container, IType type, IJavaClassField field, boolean isStatic, boolean simplePropertyProcessing)
   {
     super( container );
     if (type == null) {
@@ -68,7 +68,7 @@ public class JavaFieldPropertyInfo extends JavaBaseFeatureInfo implements IJavaF
     }
     _isStatic = isStatic;
     //_strName = NewIntrospector.capitalizeFirstChar( _field.getName() ).replace( '$', '_' );
-    _strName = _field.getName().replace( '$', '_' );
+    _strName = simplePropertyProcessing ? _field.getName() : _field.getName().replace( '$', '_' );
     if( _isStatic )
     {
       _accessor = new StaticAccessor();

--- a/gosu-core/src/main/java/gw/internal/gosu/parser/JavaTypeInfo.java
+++ b/gosu-core/src/main/java/gw/internal/gosu/parser/JavaTypeInfo.java
@@ -8,6 +8,7 @@ import gw.config.CommonServices;
 import gw.internal.gosu.parser.java.classinfo.CompileTimeExpressionParser;
 import gw.lang.GosuShop;
 import gw.lang.annotation.Annotations;
+import gw.lang.SimplePropertyProcessing;
 import gw.lang.javadoc.IClassDocNode;
 import gw.lang.javadoc.IDocRef;
 import gw.lang.parser.IExpression;
@@ -133,6 +134,7 @@ public class JavaTypeInfo extends JavaBaseFeatureInfo implements IJavaTypeInfo
           TypeSystem.lock();
           try
           {
+            boolean simplePropertyProcessing = _backingClass.getAnnotation(SimplePropertyProcessing.class) != null;
             IJavaClassField[] fields = _backingClass.getDeclaredFields();
             for( IJavaClassField field : fields )
             {
@@ -146,7 +148,7 @@ public class JavaTypeInfo extends JavaBaseFeatureInfo implements IJavaTypeInfo
               {
                 TypeVarToTypeMap actualParamByVarName =
                         TypeLord.mapTypeByVarName( getOwnersType(), getOwnersType(), true );
-                JavaFieldPropertyInfo staticProp = new JavaFieldPropertyInfo( JavaTypeInfo.this, field.getGenericType().getActualType( actualParamByVarName, true ), field, true );
+                JavaFieldPropertyInfo staticProp = new JavaFieldPropertyInfo( JavaTypeInfo.this, field.getGenericType().getActualType( actualParamByVarName, true ), field, true, simplePropertyProcessing );
                 int pos = getPosition(properties, staticProp.getName());
                 // We favor non-static over static
                 if( pos == -1 || properties.get(pos).isStatic() )
@@ -172,7 +174,7 @@ public class JavaTypeInfo extends JavaBaseFeatureInfo implements IJavaTypeInfo
                 if (field.getGenericType() == null) {
                   throw new IllegalStateException("The generic type for the field " + field.getName() + " on " + _backingClass.getName() + " was null");
                 }
-                JavaFieldPropertyInfo prop = new JavaFieldPropertyInfo( JavaTypeInfo.this, field.getGenericType().getActualType( actualParamByVarName, true ), field, false );
+                JavaFieldPropertyInfo prop = new JavaFieldPropertyInfo( JavaTypeInfo.this, field.getGenericType().getActualType( actualParamByVarName, true ), field, false, simplePropertyProcessing );
                 int pos = getPosition(properties, prop.getName());
                 // We favor non-static over static
                 if( pos == -1 || properties.get(pos) instanceof JavaFieldPropertyInfo )

--- a/gosu-test/src/main/java/gw/internal/gosu/regression/JavaClassWithDollarSignSimpleProperties.java
+++ b/gosu-test/src/main/java/gw/internal/gosu/regression/JavaClassWithDollarSignSimpleProperties.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2014 Guidewire Software, Inc.
+ */
+
+package gw.internal.gosu.regression;
+
+import gw.lang.SimplePropertyProcessing;
+
+@SimplePropertyProcessing
+public class JavaClassWithDollarSignSimpleProperties {
+  public static final String $100 = "$100";
+}

--- a/gosu-test/src/test/gosu/gw/internal/gosu/regression/UsingJavaDollarSignSimplePropertiesTest.gs
+++ b/gosu-test/src/test/gosu/gw/internal/gosu/regression/UsingJavaDollarSignSimplePropertiesTest.gs
@@ -1,0 +1,20 @@
+package gw.internal.gosu.regression
+uses gw.test.TestClass
+
+class UsingJavaDollarSignSimplePropertiesTest extends TestClass {
+  
+  function testAccessPropertyAsIdentifier() {
+    assertEquals("$100", new ExtendsDollarSignClass().accessPropertyAsIdentifier())  
+  }
+  
+  function testAccessPropertyAsMemberAccess() {
+    assertEquals("$100", JavaClassWithDollarSignSimpleProperties.$100)
+  }
+  
+  static class ExtendsDollarSignClass extends JavaClassWithDollarSignSimpleProperties {
+    function accessPropertyAsIdentifier() : String {
+      return $100
+    }
+  }
+
+}


### PR DESCRIPTION
Honor @SimplePropertyProcessing annotation for field properties so we can actually have property starting with '$' in Gosu.
