### PR TITLE
Make test timing available via sys param

### DIFF
--- a/gosu-test-api/src/main/java/gw/test/TestExecutionManager.java
+++ b/gosu-test-api/src/main/java/gw/test/TestExecutionManager.java
@@ -44,7 +44,7 @@ public class TestExecutionManager {
   // TODO - AHK - Combine with _suiteStartTime
   private long _suiteStartTimeNs = 0L;
 
-  private static boolean INCLUDE_TEST_TIMING_INFO = false;
+  private static boolean INCLUDE_TEST_TIMING_INFO = Boolean.getBoolean("gw.test.timing.info");
 
   public void setEnvironment(TestEnvironment environment) {
     _environment = environment;


### PR DESCRIPTION
Define a new system parameter, gw.test.timing.info, to control the
initial value of the INCLUDE_TEST_TIMING_INFO static variable. This
allows users to capture timing info for tests without having to modify
Gosu source.

By the way, this is unrelated to the entity typeloader changes. This is just something I wanted to change while looking at something in f-master.
