### PR TITLE
(Squashed) contributed tests since 20170627

### DIFF
--- a/gosu-test/src/test/gosu/gw/specContrib/classes/Errant_AbstractEnumsNotAllowed.gs
+++ b/gosu-test/src/test/gosu/gw/specContrib/classes/Errant_AbstractEnumsNotAllowed.gs
@@ -1,0 +1,8 @@
+package gw.specContrib.classes
+
+abstract enum Errant_AbstractEnumsNotAllowed {  //## issuekeys: MODIFIER 'ABSTRACT' NOT ALLOWED HERE
+  A; //## issuekeys: MSG_CANNOT_CONSTRUCT_ABSTRACT_CLASS
+
+  abstract function foo()                       // issuekeys: MODIFIER 'ABSTRACT' NOT ALLOWED HERE
+                                                // Studio flags the above but Gosu does not
+}

--- a/gosu-test/src/test/gosu/gw/specContrib/classes/property_Declarations/Errant_OverrideGetMethodGosu.gs
+++ b/gosu-test/src/test/gosu/gw/specContrib/classes/property_Declarations/Errant_OverrideGetMethodGosu.gs
@@ -1,0 +1,7 @@
+package gw.specContrib.classes.property_Declarations
+
+class Errant_OverrideGetMethodGosu extends Errant_OverrideGetMethodJava {
+  override function get() : String {   //No error expected as get() in Java should not create a property
+    return null
+  }
+}

--- a/gosu-test/src/test/gosu/gw/specContrib/expressions/cast/typecastContextType/Errant_CastInOperations.gs
+++ b/gosu-test/src/test/gosu/gw/specContrib/expressions/cast/typecastContextType/Errant_CastInOperations.gs
@@ -19,9 +19,8 @@ class Errant_CastInOperations {
     var bool8 = (new Integer[]{1, 2, 3}).equals({1, 2, 3} as Integer[])                //## issuekeys: INCONVERTIBLE TYPES; CANNOT CAST 'JAVA.UTIL.ARRAYLIST<JAVA.LANG.INTEGER>' TO 'JAVA.LANG.INTEGER[]'
 
     //IDE-4106
-//    var bool9 = (new Integer[]{1, 2, 3}) == ({1, 2, 3} as Integer[])  //Roperand in parenthesis
-    //IDE-4106
-//    var bool10 = (new Integer[]{1, 2, 3}) == {1, 2, 3} as Integer[]
+    var bool9 = (new Integer[]{1, 2, 3}) == ({1, 2, 3} as Integer[])  //Roperand in parenthesis //## issuekeys: MSG_UNNECESSARY_COERCION
+    var bool10 = (new Integer[]{1, 2, 3}) == {1, 2, 3} as Integer[] //## issuekeys: MSG_UNNECESSARY_COERCION
 
     var bb = {1, 2, 3}.addAll(new Integer[]{1, 2, 3} as ArrayList<Integer>)      //## issuekeys: INCONVERTIBLE TYPES; CANNOT CAST 'JAVA.LANG.INTEGER[]' TO 'JAVA.UTIL.ARRAYLIST<JAVA.LANG.INTEGER>'
 

--- a/gosu-test/src/test/gosu/gw/specContrib/generics/Errant_ExtendRawTypeWithRecoursiveTypeArgument.gs
+++ b/gosu-test/src/test/gosu/gw/specContrib/generics/Errant_ExtendRawTypeWithRecoursiveTypeArgument.gs
@@ -1,0 +1,23 @@
+package gw.specContrib.generics
+
+class Errant_ExtendRawTypeWithRecoursiveTypeArgument {
+  interface I1<T extends I1> {}
+
+  class C1 implements I1 {} //## issuekeys:  MSG_CANNOT_EXTEND_RAW_GENERIC_TYPE
+
+  interface I2<T extends I2<T>> {}
+
+  class C2 implements I2 {} //## issuekeys:  MSG_CANNOT_EXTEND_RAW_GENERIC_TYPE
+
+  interface I3<T extends Comparable<Comparable<T>>> {}
+
+  class C3 implements I3 {} //## issuekeys:  MSG_CANNOT_EXTEND_RAW_GENERIC_TYPE
+
+  interface I4<T extends Comparable<Comparable<I4>>> {}
+
+  class C4 implements I4 {} //## issuekeys:  MSG_CANNOT_EXTEND_RAW_GENERIC_TYPE
+
+  abstract class AC1<T extends AC1<T>> {}
+
+  class C5 extends AC1 {} //## issuekeys:  MSG_CANNOT_EXTEND_RAW_GENERIC_TYPE
+}

--- a/gosu-test/src/test/gosu/gw/specContrib/statements/usesStatement/Errant_ImportsInGosuProgram.gsp
+++ b/gosu-test/src/test/gosu/gw/specContrib/statements/usesStatement/Errant_ImportsInGosuProgram.gsp
@@ -1,0 +1,6 @@
+uses java.math.BigDecimal
+
+print(BigDecimal.valueOf(1))
+
+uses java.math.BigInteger       //## issuekeys: MSG_UNEXPECTED_TOKEN
+uses java.math.BigInteger#ONE   //## issuekeys: MSG_UNEXPECTED_TOKEN

--- a/gosu-test/src/test/gosu/gw/specContrib/typeinference/Errant_DiamondInference.gs
+++ b/gosu-test/src/test/gosu/gw/specContrib/typeinference/Errant_DiamondInference.gs
@@ -1,0 +1,14 @@
+package gw.specContrib.typeinference
+
+// IDE-4166
+
+class Errant_DiamondInference {
+
+    function hello<T>(t : T) : T { return null}
+
+    function foo() {
+      var bar: ArrayList<Integer> = hello(new ArrayList())  // Okay
+      var bar2: ArrayList<Integer> = hello(new ArrayList<String>( ))  //## issuekeys: The type "java.util.ArrayList<java.lang.String>" cannot be converted to "java.util.ArrayList<java.lang.Integer>"
+    }
+
+}

--- a/gosu-test/src/test/gosu/gw/specContrib/typeinference/GenericResultToParameter.gs
+++ b/gosu-test/src/test/gosu/gw/specContrib/typeinference/GenericResultToParameter.gs
@@ -1,0 +1,103 @@
+package gw.specContrib.typeinference
+
+/**
+ * Test for IDE-4142 and IDE-4166, both of which require "reverse" inference from a generic method's return type
+ * to its parameter type(s).
+ *
+ * IDE-4166: In hello() below, the parameter type and return type are the same, so in foo(), when
+ * hello() is assigned to a variable of type ArrayList<Integer>, the Gosu compiler reverse-infers that the argument
+ * new ArrayList() should be coerced to new ArrayList<Integer>.
+ *
+ * IDE-4142: The call to parseRules() below is a more general case.  Here, the matching of generic parameters is buried more
+ * deeply.  Specifically, the method reduceList() is being returned as Either<List<String>, List<Pair<Whatever1, Whatever2>>>
+ * which is like assigning a variable of that type to the call to reduceList().  The generic parameters of the return
+ * type of reduceList() thus get "reverse" inferred to the formal parameter types of reduceList().
+ */
+class GenericResultToParameter {
+
+  function hello<T>(t: T): T {
+    return null
+  }
+
+  /**
+   * IDE-4166
+   */
+  function foo() {
+    var bar: ArrayList<Integer> = hello(new ArrayList( ))  // Should be okay
+  }
+
+
+  static class Whatever1 {
+  }
+
+  static class Whatever2 {
+  }
+
+  static abstract class Goal {
+  }
+
+  static class Either<L, R> {
+    function getLeft<L1>(): L1 {
+      return null
+    }
+
+    function getRight<R1>(): R1 {
+      return null
+    }
+
+    function mapLeft<L1>(f(arg: L): L1): Either<L1, R> {
+      return new Either<L1, R>()
+    }
+
+    function mapRight<R1>(f: (arg: R): R1): Either<L, R1> {
+      return new Either<L, R1>()
+    }
+  }
+
+  static class Pair<L, R> {
+    public construct(l: L, r: R) {
+    }
+
+    public function getL(): L {
+      return null
+    }
+
+    public function getR(): R {
+      return null
+    }
+  }
+
+  /**
+   * IDE-4142
+   */
+  private static function parseRules(
+      rules: Hashtable<Object, Object>,
+      goals(tgt: String): Either<String, Goal>
+  ): Either<List<String>, List<Pair<Whatever1, Whatever2>>> {
+    final var parsedGoals =
+        rules.entrySet()
+            .map(\entry ->
+                goals(entry.Value.toString())
+                    .mapLeft(\err -> "Error: " + err)
+                    .mapRight(\goal -> createPair(goal))
+            )
+    // parsedGoals' type is: java.util.List<Either<Object,Pair<Whatever1, Whatever2>>>
+    var x = parsedGoals.get(0).getLeft()  // x's type is Object
+    var y = parsedGoals.get(0).getRight() // y's type is Pair<Whatever1, Whatever2>
+    // Should infer left of Either as String, not Object, which appears to be the problem below.
+    // Changing the return type of parseRules to : Either<List<Object>, List<Pair<Whatever1, Whatever2>>> fixes it.
+    return reduceList(parsedGoals)    // Should be okay
+  }
+
+  static function reduceList<L1, R1>(items: Iterable<Either<L1, R1>>): Either<List<L1>, List<R1>> {
+    return null
+  }
+
+  private static function createPair(goal: Goal): Pair<Whatever1, Whatever2> {
+    return new Pair(
+        new Whatever1(),
+        new Whatever2()
+    )
+  }
+
+}

--- a/gosu-test/src/test/java/gw/specContrib/classes/property_Declarations/Errant_OverrideGetMethodJava.java
+++ b/gosu-test/src/test/java/gw/specContrib/classes/property_Declarations/Errant_OverrideGetMethodJava.java
@@ -1,0 +1,7 @@
+package gw.specContrib.classes.property_Declarations;
+
+public class Errant_OverrideGetMethodJava {
+    public String get() {
+        return null;
+    }
+}


### PR DESCRIPTION
IDE-3970 Throwable when quick fix to implement abstract method in an enum

Test for IDE-4142 and IDE-4166

Enable tests for IDE-4106

IDE-4124 ParseResultsException occurs in scratchpad when 'uses' statement is not the first

Add Errant test for IDE-4166: Diamond inference

Fix name of class in test file

IDE-4064 StackOverflowError when implementing methods for ISequenceable

IDE-4601: get() in Java class should not create an empty property

20180226 - additions since 20170617

These are changes that had to be added to pass 'mvn test'