### PR TITLE
Fix line counting error with nested comments

### DIFF
--- a/gosu-core/src/main/java/gw/internal/gosu/parser/SourceCodeTokenizerInternal.java
+++ b/gosu-core/src/main/java/gw/internal/gosu/parser/SourceCodeTokenizerInternal.java
@@ -1310,6 +1310,7 @@ final public class SourceCodeTokenizerInternal
       {
         consumeBlockComment();
         prev = -1;
+        c = _peekc;
       }
       else
       {


### PR DESCRIPTION
In a situation where a nested block comment closed as the last characters on the line before the LF, the LF itself would be consumed and skipped. This would throw off the line number for the rest of the tokens in the file.

This issue affects files using LF as EOL markers. It does not affect files using CRLF.

Here is a sample class that exhibits the behavior:
```
class Test {
  function test1() {
    print('test1')
  }

  /**
   Multiline comment with nested comment
   /* nested comment */
   End multiline comment
   */

  function test2() {
    print('test2')
  }
}
```

If you run the tokenizer without the fix, you will see the tokens for the test2 function marked as line 11, but they should be line 12. After the fix, the line number is correct.