### PR TITLE
Assignability cache fix + regression test

### DIFF
--- a/gosu-core/src/main/java/gw/internal/gosu/parser/TypeLord.java
+++ b/gosu-core/src/main/java/gw/internal/gosu/parser/TypeLord.java
@@ -77,7 +77,7 @@ public class TypeLord
 {
   // LRUish cache of assignability results (recent tests indicate 99% hit rates)
   private static final TypeSystemAwareCache<Pair<IType, IType>, Boolean> ASSIGNABILITY_CACHE =
-    TypeSystemAwareCache.make( "Assignability Cache", 1000,
+    TypeSystemAwareCache.make( "Assignability Cache", getAssignabilityCacheSize(),
                                new Cache.MissHandler<Pair<IType, IType>, Boolean>()
                                {
                                  public final Boolean load( Pair<IType, IType> key )
@@ -85,6 +85,25 @@ public class TypeLord
                                    return areGenericOrParameterizedTypesAssignableInternal( key.getFirst(), key.getSecond() );
                                  }
                                } );
+
+  private static final int DEFAULT_ASSIGNABILITY_CACHE_SIZE = 1000;
+
+  private static int getAssignabilityCacheSize()
+  {
+    try
+    {
+      String assignabilityCacheSize = System.getProperty("assignabilityCacheSize");
+      if (assignabilityCacheSize != null)
+      {
+        return Math.max(Integer.valueOf(assignabilityCacheSize), DEFAULT_ASSIGNABILITY_CACHE_SIZE);
+      }
+    }
+    catch (Exception e)
+    {
+      new RuntimeException("Unable to set value of assignability cache due to an exception, the default value will be used", e).printStackTrace();
+    }
+    return DEFAULT_ASSIGNABILITY_CACHE_SIZE;
+  }
 
   public static Set<IType> getAllClassesInClassHierarchyAsIntrinsicTypes( IJavaClassInfo cls )
   {

--- a/gosu-test/src/test/java/gw/internal/gosu/parser/TypeLordTest.java
+++ b/gosu-test/src/test/java/gw/internal/gosu/parser/TypeLordTest.java
@@ -22,6 +22,7 @@ import gw.test.TestClass;
 import gw.util.GosuTestUtil;
 
 import java.io.Serializable;
+import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Arrays;
 
@@ -428,5 +429,47 @@ public class TypeLordTest extends TestClass
     IType actual = TypeLord.findLeastUpperBound( Arrays.asList( listOfWildcardOfString, listOfWildcardOfCharSequence ) );
     assertEquals(JavaTypes.LIST().getParameterizedType(JavaTypes.CHAR_SEQUENCE()), actual );
   }
+
+  private void setCacheSize(int value) {
+    System.setProperty("assignabilityCacheSize", String.valueOf(value));
+  }
+
+  private int getAssignabilityCacheSizeFromTypeLord() {
+    int size = 0;
+    TypeLord typeLord = new TypeLord();
+    try {
+      Method method = typeLord.getClass().getDeclaredMethod("getAssignabilityCacheSize");
+      method.setAccessible(true);
+      size = (int) method.invoke(typeLord);
+
+    } catch (Exception e) {
+      fail("Exception: " + e.getMessage());
+    }
+
+    return size;
+  }
+
+  public void testAssignabilityCacheSizeOveride() {
+
+    String originalPropertyValue = System.getProperty("assignabilityCacheSize");
+    try {
+      final int DEFAULT_CACHE_SIZE = 1000;
+      final int CACHE_SIZE_LESS_THAN_DEFAULT = 500;
+      final int CACHE_SIZE_GREATER_THAN_DEFAULT = 2000;
+
+      setCacheSize(CACHE_SIZE_LESS_THAN_DEFAULT);
+      assertEquals(DEFAULT_CACHE_SIZE, getAssignabilityCacheSizeFromTypeLord());
+
+      setCacheSize(CACHE_SIZE_GREATER_THAN_DEFAULT);
+      assertEquals(CACHE_SIZE_GREATER_THAN_DEFAULT, getAssignabilityCacheSizeFromTypeLord());
+
+    } finally {
+      if (originalPropertyValue == null)
+        System.clearProperty("assignabilityCacheSize");
+      else
+        System.setProperty("assignabilityCacheSize", originalPropertyValue);
+    }
+  }
+
 
 }


### PR DESCRIPTION
I squashed the two commits affecting the assignability cache behavior together.

Thanks @sadheeshv for adding the test.