### PR TITLE
Replaced hard coded java.lang.Throwable by class.getName()

### DIFF
--- a/gosu-lab/src/main/java/editor/debugger/Breakpoint.java
+++ b/gosu-lab/src/main/java/editor/debugger/Breakpoint.java
@@ -25,7 +25,7 @@ public class Breakpoint implements IJsonIO
     {
       protected Breakpoint init()
       {
-        Breakpoint anyException = new Breakpoint( "java.lang.Throwable", true, true, true );
+        Breakpoint anyException = new Breakpoint( Throwable.class.getName(), true, true, true );
         anyException.setActive( false );
         return anyException;
       }


### PR DESCRIPTION
The String value for java.lang.Throwable can be replaced by class.getName() method to avoid hard-coding the String value.