### PR TITLE
Fix JSON serialisation of empty expando objects

### DIFF
--- a/gosu-core-api/src/main/gosu/gw/lang/enhancements/CoreBindingsEnhancement.gsx
+++ b/gosu-core-api/src/main/gosu/gw/lang/enhancements/CoreBindingsEnhancement.gsx
@@ -118,8 +118,9 @@ enhancement CoreBindingsEnhancement : Bindings {
     var iKey = 0
     indent( sb, indent )
     sb.append( "new" ).append( bWithDynamic ? " Dynamic()" : "()" )
+    sb.append(" {")
     if( this.size() > 0) {
-      sb.append(" {\n")
+      sb.append("\n")
       for( key in this.keySet() ) {
         indent( sb, indent + 2 )
         sb.append( ":" ).append( key ).append( " = " )


### PR DESCRIPTION
Currently an empty expando object will create invalid JSON like this: 
{
  "emptyObject":   }
}
After this change it will generate valid JSON like this:
{
  "emptyObject":  {  }
}