### PR TITLE
build: normalize all timestamps in jars.  Fixes #194

### DIFF
--- a/gosu-doc/pom.xml
+++ b/gosu-doc/pom.xml
@@ -148,7 +148,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>2.3.2</version>
         <configuration>
           <archive>
             <manifest>
@@ -163,7 +162,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>2.2.1</version>
         <executions>
           <execution>
             <id>attach-sources</id>

--- a/gosu-parent/pom.xml
+++ b/gosu-parent/pom.xml
@@ -35,6 +35,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.build.outputTimestamp>1980-02-01T00:00:00Z</project.build.outputTimestamp>
     <dist.mvn.central.snapshotrepo.url>https://central.sonatype.com/repository/maven-snapshots/</dist.mvn.central.snapshotrepo.url>
     <scm.root>scm:git:git@github.com:gosu-lang</scm.root>
   </properties>
@@ -76,7 +77,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-source-plugin</artifactId>
-          <version>2.2.1</version>
+          <version>3.2.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -122,7 +123,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
-          <version>2.3.2</version>
+          <version>3.2.2</version>
           <configuration>
             <archive>
               <manifest>
@@ -156,7 +157,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>3.0.1</version>
+        <version>3.2.0</version>
         <configuration>
           <encoding>UTF-8</encoding>
         </configuration>
@@ -168,7 +169,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>2.2.1</version>
         <executions>
           <execution>
             <id>attach-sources</id>

--- a/gosu/pom.xml
+++ b/gosu/pom.xml
@@ -48,7 +48,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>2.3</version>
         <configuration>
           <descriptors>
             <descriptor>${project.build.assemblyDescriptorDirectory}/full.xml</descriptor>
@@ -64,14 +63,6 @@
             </goals>
           </execution>
         </executions>
-        <dependencies>
-          <dependency>
-            <!-- Fixes issue with wrong permissions set in zips (http://jira.codehaus.org/browse/MASSEMBLY-449) -->
-            <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-archiver</artifactId>
-            <version>2.2</version>
-          </dependency>
-        </dependencies>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
This makes builds reproducible and reduces the noise when comparing artifacts across releases

The timestamp is modeled after Gradle's equivalent.  See https://github.com/gradle/gradle/blob/v8.7.0/subprojects/core/src/main/java/org/gradle/api/internal/file/archive/ZipCopyAction.java#L55

Maven plugins are updated to their minimum required version where necessary.  See https://maven.apache.org/plugins/maven-artifact-plugin/plugin-issues.html

Finally, remove manually-substituted plexus-archive dependency; newer version of assembly plugin should make this unnecessary