### PR TITLE
ci: fix broken version validation regex

### DIFF
--- a/.github/workflows/release-gosu.yml
+++ b/.github/workflows/release-gosu.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Validate version format
         run: |
           VERSION="${{ inputs.version }}"
-          REGEX='^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9
+          REGEX='^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$'
           if [[ ! "$VERSION" =~ $REGEX ]]; then
             echo "Error: Version '$VERSION' does not match the standard SemVer format."
             exit 1


### PR DESCRIPTION
The expression was truncated on the previous PR