### PR TITLE
Optimize classpath initialization: cache ResourcePath, fix hashCode contracts, use HashSet for dedup

### DIFF
--- a/gosu-ant-tools/pom.xml
+++ b/gosu-ant-tools/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.gosu-lang.gosu</groupId>
     <artifactId>gosu-parent</artifactId>
-    <version>1.18.8-SNAPSHOT</version>
+    <version>1.18.8-RB-SNAPSHOT</version>
     <relativePath>../gosu-parent/pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/gosu-core-api-precompiled/pom.xml
+++ b/gosu-core-api-precompiled/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.gosu-lang.gosu</groupId>
     <artifactId>gosu-parent</artifactId>
-    <version>1.18.8-SNAPSHOT</version>
+    <version>1.18.8-RB-SNAPSHOT</version>
     <relativePath>../gosu-parent/pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/gosu-core-api/pom.xml
+++ b/gosu-core-api/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.gosu-lang.gosu</groupId>
     <artifactId>gosu-parent</artifactId>
-    <version>1.18.8-SNAPSHOT</version>
+    <version>1.18.8-RB-SNAPSHOT</version>
     <relativePath>../gosu-parent/pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/gosu-core-api/src/main/java/gw/fs/ResourcePath.java
+++ b/gosu-core-api/src/main/java/gw/fs/ResourcePath.java
@@ -20,6 +20,7 @@ public class ResourcePath {
 
   protected final ResourcePath _parent;
   protected final String _name;
+  private int _hashCode;
 
   protected ResourcePath(ResourcePath parent, String name) {
     if (name == null) {
@@ -246,9 +247,16 @@ public class ResourcePath {
 
   @Override
   public int hashCode() {
-    int result = _parent != null ? _parent.hashCode() : 0;
-    result = 31 * result + (_name != null ? _name.hashCode() : 0);
-    return result;
+    int h = _hashCode;
+    if (h == 0) {
+      h = _parent != null ? _parent.hashCode() : 0;
+      h = 31 * h + (_name != null ? _name.hashCode() : 0);
+      if (h == 0) {
+        h = 1;
+      }
+      _hashCode = h;
+    }
+    return h;
   }
 
   public boolean isChild(ResourcePath path) {

--- a/gosu-core-api/src/main/java/gw/fs/jar/JarFileDirectoryImpl.java
+++ b/gosu-core-api/src/main/java/gw/fs/jar/JarFileDirectoryImpl.java
@@ -29,6 +29,7 @@ public class JarFileDirectoryImpl implements IJarFileDirectory {
 
   private File _file;
   private JarFile _jarFile;
+  private ResourcePath _path;
   private Map<String, IResource> _resources;
   private List<IDirectory> _childDirs;
   private List<IFile> _childFiles;
@@ -195,7 +196,12 @@ public class JarFileDirectoryImpl implements IJarFileDirectory {
 
   @Override
   public ResourcePath getPath() {
-    return ResourcePath.parse(_file.getAbsolutePath());
+    ResourcePath p = _path;
+    if (p == null) {
+      p = ResourcePath.parse(_file.getAbsolutePath());
+      _path = p;
+    }
+    return p;
   }
 
   @Override
@@ -249,6 +255,11 @@ public class JarFileDirectoryImpl implements IJarFileDirectory {
     } else {
       return false;
     }
+  }
+
+  @Override
+  public int hashCode() {
+    return getPath().hashCode();
   }
 
   @Override

--- a/gosu-core-api/src/main/java/gw/fs/physical/PhysicalResourceImpl.java
+++ b/gosu-core-api/src/main/java/gw/fs/physical/PhysicalResourceImpl.java
@@ -97,6 +97,11 @@ public class PhysicalResourceImpl implements IResource {
   }
 
   @Override
+  public int hashCode() {
+    return _path.hashCode();
+  }
+
+  @Override
   public String toString() {
     return getPath().getFileSystemPathString();
   }

--- a/gosu-core/pom.xml
+++ b/gosu-core/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.gosu-lang.gosu</groupId>
     <artifactId>gosu-parent</artifactId>
-    <version>1.18.8-SNAPSHOT</version>
+    <version>1.18.8-RB-SNAPSHOT</version>
     <relativePath>../gosu-parent/pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/gosu-core/src/main/java/gw/internal/gosu/module/Module.java
+++ b/gosu-core/src/main/java/gw/internal/gosu/module/Module.java
@@ -37,6 +37,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.jar.Attributes;
@@ -155,6 +156,7 @@ public class Module implements IModule
     extensions.add(".java");
     extensions.add(".xsd");
     extensions.addAll(Arrays.asList(GosuClassTypeLoader.ALL_EXTS));
+    Set<IDirectory> seen = new HashSet<>(roots);
     //noinspection Convert2streamapi
     for (IDirectory root : paths) {
       // roots without manifests are considered source roots
@@ -164,7 +166,7 @@ public class Module implements IModule
               // http://www.coderanch.com/t/69641/BEA-Weblogic/wl-cls-gen-jar-coming
               // So we need to always treat it as containing sources
               root.getName().equals("_wl_cls_gen.jar")) {
-        if( !roots.contains( root ) )
+        if( seen.add( root ) )
         {
           roots.add( root );
         }
@@ -236,14 +238,11 @@ public class Module implements IModule
       return classpath;
     }
 
-    ArrayList<IDirectory> newClasspath = new ArrayList<>();
+    LinkedHashSet<IDirectory> newClasspath = new LinkedHashSet<>();
     for( IDirectory root : classpath )
     {
       //add the root JAR itself first, preserving ordering
-      if( !newClasspath.contains( root ) )
-      {
-        newClasspath.add( root );
-      }
+      newClasspath.add( root );
       if( root instanceof JarFileDirectoryImpl )
       {
         JarFile jarFile = ((JarFileDirectoryImpl)root).getJarFile();
@@ -272,10 +271,7 @@ public class Module implements IModule
                 }
                 File dirOrJar = new File( url.toURI() );
                 IDirectory idir = CommonServices.getFileSystem().getIDirectory( dirOrJar );
-                if( !newClasspath.contains( idir ) )
-                {
-                  newClasspath.add( idir );
-                }
+                newClasspath.add( idir );
               }
             }
           }
@@ -287,7 +283,7 @@ public class Module implements IModule
       }
     }
 
-    return newClasspath;
+    return new ArrayList<>( newClasspath );
   }
 
   @Override

--- a/gosu-doc/pom.xml
+++ b/gosu-doc/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.gosu-lang.gosu</groupId>
     <artifactId>gosu-parent</artifactId>
-    <version>1.18.8-SNAPSHOT</version>
+    <version>1.18.8-RB-SNAPSHOT</version>
     <relativePath>../gosu-parent/pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/gosu-lab/pom.xml
+++ b/gosu-lab/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.gosu-lang.gosu</groupId>
     <artifactId>gosu-parent</artifactId>
-    <version>1.18.8-SNAPSHOT</version>
+    <version>1.18.8-RB-SNAPSHOT</version>
     <relativePath>../gosu-parent/pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/gosu-maven-compiler/pom.xml
+++ b/gosu-maven-compiler/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.gosu-lang.gosu</groupId>
     <artifactId>gosu-parent</artifactId>
-    <version>1.18.8-SNAPSHOT</version>
+    <version>1.18.8-RB-SNAPSHOT</version>
     <relativePath>../gosu-parent/pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/gosu-parent/pom.xml
+++ b/gosu-parent/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>org.gosu-lang.gosu</groupId>
   <artifactId>gosu-parent</artifactId>
-  <version>1.18.8-SNAPSHOT</version>
+  <version>1.18.8-RB-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Gosu :: Parent POM</name>

--- a/gosu-process/pom.xml
+++ b/gosu-process/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.gosu-lang.gosu</groupId>
     <artifactId>gosu-parent</artifactId>
-    <version>1.18.8-SNAPSHOT</version>
+    <version>1.18.8-RB-SNAPSHOT</version>
     <relativePath>../gosu-parent/pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/gosu-test-api/pom.xml
+++ b/gosu-test-api/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.gosu-lang.gosu</groupId>
     <artifactId>gosu-parent</artifactId>
-    <version>1.18.8-SNAPSHOT</version>
+    <version>1.18.8-RB-SNAPSHOT</version>
     <relativePath>../gosu-parent/pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/gosu-test/pom.xml
+++ b/gosu-test/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.gosu-lang.gosu</groupId>
     <artifactId>gosu-parent</artifactId>
-    <version>1.18.8-SNAPSHOT</version>
+    <version>1.18.8-RB-SNAPSHOT</version>
     <relativePath>../gosu-parent/pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/gosu/pom.xml
+++ b/gosu/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.gosu-lang.gosu</groupId>
     <artifactId>gosu-parent</artifactId>
-    <version>1.18.8-SNAPSHOT</version>
+    <version>1.18.8-RB-SNAPSHOT</version>
     <relativePath>../gosu-parent/pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gosu-lang.gosu</groupId>
     <artifactId>gosu-parent</artifactId>
-    <version>1.18.8-SNAPSHOT</version>
+    <version>1.18.8-RB-SNAPSHOT</version>
     <relativePath>gosu-parent</relativePath>
   </parent>
   <artifactId>gosu-proj</artifactId>


### PR DESCRIPTION
Commit 1 is performance enhancement, suggested by Claude Code.  This shaves 20 seconds off of a PolicyCenter (dev) compilation.

Commit 2 is temporary and needs to be dropped before merge.