### PR TITLE
Fix malformed JVM generic signature for type parameters with mixed bounds

### DIFF
--- a/gosu-core-api/src/main/java/gw/lang/ir/IRClass.java
+++ b/gosu-core-api/src/main/java/gw/lang/ir/IRClass.java
@@ -131,16 +131,7 @@ public class IRClass {
           } else {
             types = new IType[] {boundingType};
           }
-          SignatureVisitor sv;
-          for(int i = types.length-1; i >= 0 ; i--) {
-            if( types[i].isInterface() ) {
-              sv = sw.visitInterfaceBound();
-            }
-            else {
-              sv = sw.visitClassBound();
-            }
-            SignatureUtil.visitType( sv, SignatureUtil.getPureGenericType(types[i]), bGeneric );
-          }
+          emitBounds( sw, types, bGeneric );
         }
         else {
           SignatureVisitor sv = sw.visitClassBound();
@@ -165,6 +156,36 @@ public class IRClass {
     }
     if( bGeneric[0] ) {
       _genericSignature = sw.toString();
+    }
+  }
+
+  // JVM spec: TypeParameter ::= Identifier ClassBound InterfaceBound*
+  // ASM's SignatureWriter.visitClassBound() is a no-op — the ':' that introduces the class
+  // bound is written by visitFormalTypeParameter, so the class bound must be emitted first
+  // (and at most one). Emitting interface bounds first, or a class bound after any interface
+  // bound, produces a malformed signature (e.g. "<P::LI;LC;>" with a missing ':' before LC).
+  public static void emitBounds( SignatureWriter sw, IType[] types, boolean[] bGeneric ) {
+    IType classBound = null;
+    List<IType> interfaceBounds = new ArrayList<>( types.length );
+    for( IType t : types ) {
+      if( t.isInterface() ) {
+        interfaceBounds.add( t );
+      } else if( classBound == null ) {
+        classBound = t;
+      } else {
+        // More than one non-interface bound is not legal, but we keep one and
+        // demote the rest to interface slots to avoid producing garbage — the
+        // parser should have rejected this case earlier.
+        interfaceBounds.add( t );
+      }
+    }
+    if( classBound != null ) {
+      SignatureVisitor sv = sw.visitClassBound();
+      SignatureUtil.visitType( sv, SignatureUtil.getPureGenericType( classBound ), bGeneric );
+    }
+    for( IType iface : interfaceBounds ) {
+      SignatureVisitor sv = sw.visitInterfaceBound();
+      SignatureUtil.visitType( sv, SignatureUtil.getPureGenericType( iface ), bGeneric );
     }
   }
 

--- a/gosu-core-api/src/main/java/gw/lang/ir/statement/IRMethodStatement.java
+++ b/gosu-core-api/src/main/java/gw/lang/ir/statement/IRMethodStatement.java
@@ -8,6 +8,7 @@ import gw.internal.ext.org.objectweb.asm.signature.SignatureVisitor;
 import gw.internal.ext.org.objectweb.asm.signature.SignatureWriter;
 import gw.lang.UnstableAPI;
 import gw.lang.ir.IRAnnotation;
+import gw.lang.ir.IRClass;
 import gw.lang.ir.IRStatement;
 import gw.lang.ir.IRSymbol;
 import gw.lang.ir.IRType;
@@ -74,16 +75,7 @@ public class IRMethodStatement extends IRStatement {
           } else {
             types = new IType[] {boundingType};
           }
-          SignatureVisitor sv;
-          for(int i = types.length-1; i >= 0 ; i--) {
-            if( types[i].isInterface() ) {
-              sv = sw.visitInterfaceBound();
-            }
-            else {
-              sv = sw.visitClassBound();
-            }
-            SignatureUtil.visitType( sv, SignatureUtil.getPureGenericType(types[i]), bGeneric );
-          }
+          IRClass.emitBounds( sw, types, bGeneric );
         }
         else {
           SignatureVisitor sv = sw.visitClassBound();

--- a/gosu-test/src/test/gosu/gw/internal/gosu/compiler/sample/signature/Sig_Class.gs
+++ b/gosu-test/src/test/gosu/gw/internal/gosu/compiler/sample/signature/Sig_Class.gs
@@ -1,0 +1,3 @@
+package gw.internal.gosu.compiler.sample.signature
+
+class Sig_Class { }

--- a/gosu-test/src/test/gosu/gw/internal/gosu/compiler/sample/signature/Sig_ClassAndInterface.gs
+++ b/gosu-test/src/test/gosu/gw/internal/gosu/compiler/sample/signature/Sig_ClassAndInterface.gs
@@ -1,0 +1,3 @@
+package gw.internal.gosu.compiler.sample.signature
+
+class Sig_ClassAndInterface<P extends Sig_Class & Sig_I1> { }

--- a/gosu-test/src/test/gosu/gw/internal/gosu/compiler/sample/signature/Sig_ClassAndTwoInterfaces.gs
+++ b/gosu-test/src/test/gosu/gw/internal/gosu/compiler/sample/signature/Sig_ClassAndTwoInterfaces.gs
@@ -1,0 +1,3 @@
+package gw.internal.gosu.compiler.sample.signature
+
+class Sig_ClassAndTwoInterfaces<P extends Sig_Class & Sig_I1 & Sig_I2> { }

--- a/gosu-test/src/test/gosu/gw/internal/gosu/compiler/sample/signature/Sig_ClassBound.gs
+++ b/gosu-test/src/test/gosu/gw/internal/gosu/compiler/sample/signature/Sig_ClassBound.gs
@@ -1,0 +1,3 @@
+package gw.internal.gosu.compiler.sample.signature
+
+class Sig_ClassBound<P extends Sig_Class> { }

--- a/gosu-test/src/test/gosu/gw/internal/gosu/compiler/sample/signature/Sig_I1.gs
+++ b/gosu-test/src/test/gosu/gw/internal/gosu/compiler/sample/signature/Sig_I1.gs
@@ -1,0 +1,3 @@
+package gw.internal.gosu.compiler.sample.signature
+
+interface Sig_I1 { }

--- a/gosu-test/src/test/gosu/gw/internal/gosu/compiler/sample/signature/Sig_I2.gs
+++ b/gosu-test/src/test/gosu/gw/internal/gosu/compiler/sample/signature/Sig_I2.gs
@@ -1,0 +1,3 @@
+package gw.internal.gosu.compiler.sample.signature
+
+interface Sig_I2 { }

--- a/gosu-test/src/test/gosu/gw/internal/gosu/compiler/sample/signature/Sig_InterfaceBound.gs
+++ b/gosu-test/src/test/gosu/gw/internal/gosu/compiler/sample/signature/Sig_InterfaceBound.gs
@@ -1,0 +1,3 @@
+package gw.internal.gosu.compiler.sample.signature
+
+class Sig_InterfaceBound<P extends Sig_I1> { }

--- a/gosu-test/src/test/gosu/gw/internal/gosu/compiler/sample/signature/Sig_MethodClassAndInterface.gs
+++ b/gosu-test/src/test/gosu/gw/internal/gosu/compiler/sample/signature/Sig_MethodClassAndInterface.gs
@@ -1,0 +1,5 @@
+package gw.internal.gosu.compiler.sample.signature
+
+class Sig_MethodClassAndInterface {
+  function foo<P extends Sig_Class & Sig_I1>( p: P ): void { }
+}

--- a/gosu-test/src/test/gosu/gw/internal/gosu/compiler/sample/signature/Sig_TwoInterfaces.gs
+++ b/gosu-test/src/test/gosu/gw/internal/gosu/compiler/sample/signature/Sig_TwoInterfaces.gs
@@ -1,0 +1,3 @@
+package gw.internal.gosu.compiler.sample.signature
+
+class Sig_TwoInterfaces<P extends Sig_I1 & Sig_I2> { }

--- a/gosu-test/src/test/java/gw/internal/gosu/compiler/signature/MalformedSignatureTest.java
+++ b/gosu-test/src/test/java/gw/internal/gosu/compiler/signature/MalformedSignatureTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2014 Guidewire Software, Inc.
+ */
+
+package gw.internal.gosu.compiler.signature;
+
+import gw.internal.ext.org.objectweb.asm.ClassReader;
+import gw.internal.ext.org.objectweb.asm.ClassVisitor;
+import gw.internal.ext.org.objectweb.asm.MethodVisitor;
+import gw.internal.ext.org.objectweb.asm.Opcodes;
+import gw.lang.reflect.TypeSystem;
+import gw.lang.reflect.gs.IGosuClass;
+import gw.test.TestClass;
+
+/**
+ * Regression tests for the JVM generic signature emitted on Gosu classes and
+ * methods whose type parameters have a mix of class and interface bounds.
+ * <p>
+ * Prior to the fix in {@code IRClass.emitBounds}, the backward iteration over
+ * bound types combined with the fact that ASM's {@code SignatureWriter.visitClassBound()}
+ * is a no-op produced signatures like {@code <P::LI;LC;>} (missing {@code :} before
+ * the class bound), which are malformed per JVM spec
+ * ({@code TypeParameter ::= Identifier ClassBound InterfaceBound*}) and which
+ * {@code javap -v} itself cannot parse.
+ */
+public class MalformedSignatureTest extends TestClass {
+
+  private static final String PKG = "gw.internal.gosu.compiler.sample.signature.";
+  private static final String PKG_SLASH = "gw/internal/gosu/compiler/sample/signature/";
+
+  public void testClass_noBound() {
+    // Single interface bound — regression-check that ordinary generics still round-trip.
+    assertClassSignatureStartsWith(
+        "Sig_InterfaceBound",
+        "<P::L" + PKG_SLASH + "Sig_I1;>"
+    );
+  }
+
+  public void testClass_twoInterfaceBounds() {
+    // Empty class bound, two interface bounds. All colons required. Source order preserved.
+    assertClassSignatureStartsWith(
+        "Sig_TwoInterfaces",
+        "<P::L" + PKG_SLASH + "Sig_I1;:L" + PKG_SLASH + "Sig_I2;>"
+    );
+  }
+
+  public void testClass_classBoundFirst() {
+    // Single non-interface bound. One colon before the class type.
+    assertClassSignatureStartsWith(
+        "Sig_ClassBound",
+        "<P:L" + PKG_SLASH + "Sig_Class;>"
+    );
+  }
+
+  public void testClass_classBoundThenInterface() {
+    // Mixed: class bound must be emitted first, then the interface.
+    // Regression: used to be emitted as ::LI;LC; (class bound last, no :).
+    assertClassSignatureStartsWith(
+        "Sig_ClassAndInterface",
+        "<P:L" + PKG_SLASH + "Sig_Class;:L" + PKG_SLASH + "Sig_I1;>"
+    );
+  }
+
+  public void testClass_classBoundThenTwoInterfaces() {
+    // The most common real-world trigger: class + multiple interfaces in source order.
+    assertClassSignatureStartsWith(
+        "Sig_ClassAndTwoInterfaces",
+        "<P:L" + PKG_SLASH + "Sig_Class;:L" + PKG_SLASH + "Sig_I1;:L" + PKG_SLASH + "Sig_I2;>"
+    );
+  }
+
+  public void testMethod_classAndInterfaceBound() {
+    // Same bug exists in IRMethodStatement.makeGenericSignature.
+    String sig = readMethodSignature( PKG + "Sig_MethodClassAndInterface", "foo" );
+    assertNotNull( "foo() should carry a generic signature", sig );
+    // Expect <P:LSig_Class;:LSig_I1;>(LP;)V or similar — order: class bound before interfaces.
+    assertTrue(
+        "method signature should start with class bound then interface bound, got: " + sig,
+        sig.startsWith( "<P:L" + PKG_SLASH + "Sig_Class;:L" + PKG_SLASH + "Sig_I1;>" )
+    );
+  }
+
+  // ---- helpers ----
+
+  private void assertClassSignatureStartsWith( String simpleName, String expectedPrefix ) {
+    String actual = readClassSignature( PKG + simpleName );
+    assertNotNull( "class " + simpleName + " should have a generic signature", actual );
+    assertTrue(
+        "expected signature to start with: " + expectedPrefix + "\nbut was: " + actual,
+        actual.startsWith( expectedPrefix )
+    );
+  }
+
+  private String readClassSignature( String fqn ) {
+    byte[] bytes = getClassBytes( fqn );
+    String[] holder = new String[1];
+    new ClassReader( bytes ).accept( new ClassVisitor( Opcodes.ASM9 ) {
+      @Override
+      public void visit( int version, int access, String name, String signature,
+                         String superName, String[] interfaces ) {
+        holder[0] = signature;
+      }
+    }, ClassReader.SKIP_CODE | ClassReader.SKIP_DEBUG | ClassReader.SKIP_FRAMES );
+    return holder[0];
+  }
+
+  private String readMethodSignature( String fqn, String methodName ) {
+    byte[] bytes = getClassBytes( fqn );
+    String[] holder = new String[1];
+    new ClassReader( bytes ).accept( new ClassVisitor( Opcodes.ASM9 ) {
+      @Override
+      public MethodVisitor visitMethod( int access, String name, String descriptor,
+                                        String signature, String[] exceptions ) {
+        if( name.equals( methodName ) && signature != null ) {
+          holder[0] = signature;
+        }
+        return null;
+      }
+    }, ClassReader.SKIP_CODE | ClassReader.SKIP_DEBUG | ClassReader.SKIP_FRAMES );
+    return holder[0];
+  }
+
+  private byte[] getClassBytes( String fqn ) {
+    IGosuClass gsClass = (IGosuClass) TypeSystem.getByFullName( fqn );
+    assertNotNull( "could not resolve type " + fqn, gsClass );
+    byte[] bytes = TypeSystem.getGosuClassLoader().getBytes( gsClass );
+    assertNotNull( "class loader produced no bytes for " + fqn, bytes );
+    return bytes;
+  }
+}


### PR DESCRIPTION
ij-gosu/jps contains a workaround for malformed JVM generic signatures emitted by Gosu.  This fixes the compiler to make the workaround unnecessary.

JVM spec requires `TypeParameter ::= Identifier ClassBound InterfaceBound*`, with the class bound (possibly empty) always before interface bounds. The signature-emission loop in IRClass.makeGenericSignature and IRMethodStatement.makeGenericSignature iterated the bounds array backward and relied on SignatureWriter.visitClassBound() to write the class-bound separator — but in ASM that method is a no-op. The ':' that introduces the class bound is actually written by visitFormalTypeParameter, so a class bound emitted after any interface bound ends up with no leading ':'.

For a source like `class G<P extends C1 & I1 & I2>` the compiler emitted

    <P::Lpkg/I2;:Lpkg/I1;Lpkg/C1;>

with the class bound `C1` last and the `:` before it missing, violating the JVM spec. javap -v itself throws StringIndexOutOfBoundsException on such signatures; ASM SignatureReader (used by the IDEA JPS dependency graph) also crashes. The ij-gosu side has a workaround that rewrites these signatures before graph ingestion — this fix lets that workaround be removed.

Rewrites emission as: partition bounds into one class bound + N interface bounds, emit the class bound first (if any), then interface bounds in source order. Shared helper `IRClass.emitBounds` is reused from IRMethodStatement to avoid duplicating the logic.

Adds regression tests in gosu-test/MalformedSignatureTest covering: single interface bound; two interface bounds; single class bound; class bound + interface; class bound + two interfaces; and the method-level variant. Tests read the emitted bytecode signature directly via ASM ClassReader and assert JVM-spec ordering.

 ## Test plan
- [ ] New regression tests (`gosu-test/MalformedSignatureTest`) cover the six signature shapes: single interface bound, two interface bounds, single class bound, class + interface, class + two interfaces, and the method-level variant. Each reads the emitted bytecode via ASM `ClassReader` and asserts JVM-spec ordering with every required `:` separator present. Verified that these tests fail on pre-fix code (4/6 failing, including the real malformed-signature bug) and pass on the fix.
- [ ] `javap -v` on the `Sig_ClassAndTwoInterfaces` fixture completes cleanly post-fix; pre-fix it throws `StringIndexOutOfBoundsException` inside `com.sun.tools.classfile.Signature.parseTypeParamType`.
- [ ] Full `mvn -pl gosu-test test` (no filter) locally to confirm no unrelated regressions in existing Gosu compilation tests.
- [ ] Downstream verification in ij-gosu: after installing the patched gosu-core-api into the local Maven cache, the `ij-gosu` integTest suite (`ClassPropertyTest`, `GenericTest`, `JavaGenericTest`, `JavaMemberChangeTest`) runs in both Graph and Mappings modes. The `GosuBytecodeAnalyzer.fixFormalTypeParams` workaround becomes unreachable on fixed bytecode; keep it in place until all consumers have rebuilt.
- [ ] Real-world spot check: confirm that a class matching the shape originally seen in the build log (`DefaultRestStreamCollectionResource` in PC, with `<P::LHasPolicyPeriod;LRestResource;>`) now emits a well-formed signature.
- [ ] CI green on both gosu-lang unit tests and the downstream ij-gosu integration suite.
