### PR TITLE
 Fix Java inheritance and degenerified-generic edge cases in the Gosu parser   

### DIFF
--- a/gosu-core-api/src/main/java/gw/lang/parser/expressions/Variance.java
+++ b/gosu-core-api/src/main/java/gw/lang/parser/expressions/Variance.java
@@ -102,7 +102,10 @@ public enum Variance
       {
         IType typeParam = typeParameters[i];
         IGenericTypeVariable[] gtvs = type.getGenericType().getGenericTypeVariables();
-        if( i < gtvs.length )
+        // gtvs may be null when an incremental build drops the type parameters from the
+        // generic type's declaration while a parameterized usage still references them —
+        // the parser would rather emit that as a proper error downstream than NPE here.
+        if( gtvs != null && i < gtvs.length )
         {
           Variance tv = null;
           if( typeParam instanceof ITypeVariableType )

--- a/gosu-core-api/src/main/java/gw/lang/reflect/gs/GosuClassTypeLoader.java
+++ b/gosu-core-api/src/main/java/gw/lang/reflect/gs/GosuClassTypeLoader.java
@@ -166,7 +166,11 @@ public class GosuClassTypeLoader extends SimpleTypeLoader
           strFullyQualifiedName.startsWith( IGosuClass.PROXY_PREFIX ) )
       {
         IType javaType = TypeSystem.getByFullNameIfValid( IGosuClass.ProxyUtil.getNameSansProxy( strFullyQualifiedName ) );
-        if( javaType instanceof IJavaType )
+        // Primitives don't get adapter classes: "_proxy_.int" is not a real type. Without this
+        // guard, resolveTypesInAllNamespaces on a proxy in the default package would match the
+        // primitive and generate a nonsense "class int {}" source that later surfaces as
+        // "_proxy_.int" in type errors.
+        if( javaType instanceof IJavaType && !javaType.isPrimitive() )
         {
           IGosuClass adapterClass = ((IJavaType)javaType).getAdapterClass();
           if( adapterClass == null )

--- a/gosu-core/src/main/java/gw/internal/gosu/parser/GosuClassProxyFactory.java
+++ b/gosu-core/src/main/java/gw/internal/gosu/parser/GosuClassProxyFactory.java
@@ -217,9 +217,23 @@ public class GosuClassProxyFactory
       type = type.getGenericType();
     }
     StringBuilder sb = new StringBuilder();
-    sb.append( "package " ).append( IGosuClass.PROXY_PREFIX ).append('.').append( type.getNamespace() ).append( '\n' );
+    appendProxyPackage( sb, type );
     genClassImpl(type, headerOnly, sb);
     return sb;
+  }
+
+  // When a Java type is in the default (unnamed) package, getNamespace() returns the empty string.
+  // Emitting "_proxy_." with a trailing dot produces invalid Gosu and the proxy source fails to
+  // parse, so the proxy ends up with no members and Gosu subclasses can't inherit them.
+  private static void appendProxyPackage( StringBuilder sb, IJavaType type )
+  {
+    sb.append( "package " ).append( IGosuClass.PROXY_PREFIX );
+    String namespace = type.getNamespace();
+    if( namespace != null && !namespace.isEmpty() )
+    {
+      sb.append( '.' ).append( namespace );
+    }
+    sb.append( '\n' );
   }
 
   private void genClassImpl( IJavaType type, boolean headerOnly, StringBuilder sb )
@@ -444,7 +458,7 @@ public class GosuClassProxyFactory
       type = type.getGenericType();
     }
     StringBuilder sb = new StringBuilder();
-    sb.append( "package " ).append( IGosuClass.PROXY_PREFIX ).append( '.' ).append( type.getNamespace() ).append('\n');
+    appendProxyPackage( sb, type );
     genInterfaceImpl( type, headerOnly, sb );
     return sb;
   }


### PR DESCRIPTION
Two independent Gosu-compiler fixes from an investigation into unexpected failures in the JPS incremental-compilation integration tests (`ij-gosu/testData/compiler/incremental`).
### 1. Gosu proxies for Java types in the default package (`f95a099eb`)
**Symptom.** A Gosu class extending a Java class in the default (empty) package could not see any of that parent's members. References to inherited fields or methods produced `"No property descriptor found for property, x, on class, B"` and related errors.
**Cause.** `GosuClassProxyFactory.genJavaClassProxy` / `genJavaInterfaceProxy` emitted the proxy source with a hard-coded trailing dot on the package line: `package _proxy_.` — invalid Gosu syntax when the namespace is empty. The proxy source failed to parse, so the resulting proxy type had no members and the Java parent's API was invisible to any subclass.
**Fix.** Extracted `appendProxyPackage()` that omits the `.` separator when the Java type's namespace is empty, replacing the inline emit at both call sites. Added a primitive guard in `GosuClassTypeLoader.getAdapterClass`. Once the default-package proxy fix above makes `_proxy_` a valid implicit import namespace, primitive names like `int` start resolving via `_proxy_.int` first and trigger adapter generation. Gosu keyword primitives can't be used as class names, so the adapter source came out as `class int {}` and failed to parse. Returning `null` for primitives lets resolution fall through to the actual primitive type.
### 2. NPE in `Variance.verifyTypeVarVariance` when a generic is degenerified (`04b3f9163`)
**Symptom.** An incremental build where a Java generic `A<T>` is modified to drop its type parameter (e.g. `A.java.new` declares plain `A`) while Gosu code still references `A<T>` produced an opaque *"Internal Gosu compiler exception"* — a `NullPointerException` inside the parser — instead of a proper parse error.
**Cause.** At the variance-check site, the parameterized type's `getGenericType().getGenericTypeVariables()` returns `null` when the generic form has been degenerified mid-build. The existing loop guard `if (i < gtvs.length)` dereferences that null array.
**Fix.** Added a null check so a null `gtvs` skips the per-parameter variance walk without crashing. The parser still emits the correct `"A is not a valid type"` error downstream from actual type resolution — now as a proper compile error rather than an internal exception.
## Test plan
  - [ ] Manually verified both scenarios against the ij-gosu integTest harness (`JavaMemberChangeTest`, `JavaGenericTest`).
  - [ ] `mvn -pl gosu-core -am test` locally.                                                                               
  - [ ] CI green.

