### PR TITLE
Fix generation of class file generic signatures

### DIFF
--- a/gosu-core-api/src/main/java/gw/lang/ir/IRClass.java
+++ b/gosu-core-api/src/main/java/gw/lang/ir/IRClass.java
@@ -16,6 +16,7 @@ import gw.lang.reflect.java.JavaTypes;
 
 import java.util.List;
 import java.util.ArrayList;
+import java.util.Set;
 
 @UnstableAPI
 public class IRClass {
@@ -127,12 +128,27 @@ public class IRClass {
         if( boundingType != null ) {
           IType[] types;
           if( boundingType instanceof ICompoundType) {
-            types = ((ICompoundType) boundingType).getTypes().toArray(new IType[0]);
+            Set<IType> allTypes = ((ICompoundType) boundingType).getTypes();
+            // Sort allTypes so that the first element is a class type, followed by interface types.
+            // This is necessary to be JVM spec compliant, and it makes sure a SignatureReader will be
+            // able to parse the signature we are emitting.
+            ArrayList<IType> clsThenIfaces = new ArrayList<>();
+            for( IType typ : allTypes ) {
+              if( !typ.isInterface() ) {
+                clsThenIfaces.add( typ );
+              }
+            }
+            for( IType typ : allTypes ) {
+              if( typ.isInterface() ) {
+                clsThenIfaces.add( typ );
+              }
+            }
+            types = clsThenIfaces.toArray( new IType[0] );
           } else {
             types = new IType[] {boundingType};
           }
           SignatureVisitor sv;
-          for(int i = types.length-1; i >= 0 ; i--) {
+          for(int i = 0; i < types.length ; i++) {
             if( types[i].isInterface() ) {
               sv = sw.visitInterfaceBound();
             }

--- a/gosu-core-api/src/main/java/gw/lang/ir/IRClass.java
+++ b/gosu-core-api/src/main/java/gw/lang/ir/IRClass.java
@@ -128,8 +128,9 @@ public class IRClass {
         if( boundingType != null ) {
           IType[] types;
           if( boundingType instanceof ICompoundType) {
+            // Note that internally getTypes() returns a SortedSet, so we can iterate allTypes deterministically.
             Set<IType> allTypes = ((ICompoundType) boundingType).getTypes();
-            // Sort allTypes so that the first element is a class type, followed by interface types.
+            // Order allTypes so that the first element is a class type, followed by interface types.
             // This is necessary to be JVM spec compliant, and it makes sure a SignatureReader will be
             // able to parse the signature we are emitting.
             ArrayList<IType> clsThenIfaces = new ArrayList<>();

--- a/gosu-test/src/test/java/gw/internal/gosu/incremental/IncrementalCompilationEndToEndIT.java
+++ b/gosu-test/src/test/java/gw/internal/gosu/incremental/IncrementalCompilationEndToEndIT.java
@@ -407,10 +407,10 @@ public class IncrementalCompilationEndToEndIT
   @Test
   public void testGenericSignatureAsmVisitorParsing() throws Exception
   {
-    File classA = createSourceFile( "example/ClassA.gs",
+    File zclassA = createSourceFile( "example/zClassA.gs",
                                   "package example\n" +
                                   "\n" +
-                                  "class ClassA {}\n");
+                                  "class zClassA {}\n");
     File ifaceA = createSourceFile( "example/IfaceA.gs",
                                   "package example\n" +
                                   "\n" +
@@ -421,7 +421,7 @@ public class IncrementalCompilationEndToEndIT
                                   "interface IfaceB {}\n" );
     File sig = createSourceFile( "example/Sig.gs",
                                  "package example\n" +
-                                 "abstract class Sig <P extends IfaceA & ClassA & IfaceB> {\n" +
+                                 "abstract class Sig <P extends IfaceB & zClassA & IfaceA> {\n" +
                                  "\n" +
                                  "}");
 
@@ -434,16 +434,16 @@ public class IncrementalCompilationEndToEndIT
       "{\n" +
       "  \"version\": \"" + DEPENDENCY_VERSION + "\",\n" +
       "  \"consumers\": {\n" +
-      "    \"example.ClassA\": [\n" +
-      "      \"example.Sig\"\n" +
-      "    ],\n" +
       "    \"example.IfaceA\": [\n" +
       "      \"example.Sig\"\n" +
       "    ],\n" +
       "    \"example.IfaceB\": [\n" +
       "      \"example.Sig\"\n" +
       "    ],\n" +
-      "    \"example.Sig\": []\n" +
+      "    \"example.Sig\": [],\n" +
+      "    \"example.zClassA\": [\n" +
+      "      \"example.Sig\"\n" +
+      "    ]\n" +
       "  }\n" +
       "}";
     assertEquals("Dep file should match the expected one", expectedDepFile, depFileContent );

--- a/gosu-test/src/test/java/gw/internal/gosu/incremental/IncrementalCompilationEndToEndIT.java
+++ b/gosu-test/src/test/java/gw/internal/gosu/incremental/IncrementalCompilationEndToEndIT.java
@@ -405,6 +405,51 @@ public class IncrementalCompilationEndToEndIT
   }
 
   @Test
+  public void testGenericSignatureAsmVisitorParsing() throws Exception
+  {
+    File classA = createSourceFile( "example/ClassA.gs",
+                                  "package example\n" +
+                                  "\n" +
+                                  "class ClassA {}\n");
+    File ifaceA = createSourceFile( "example/IfaceA.gs",
+                                  "package example\n" +
+                                  "\n" +
+                                  "interface IfaceA {}\n");
+    File ifaceB = createSourceFile( "example/IfaceB.gs",
+                                  "package example\n" +
+                                  "\n" +
+                                  "interface IfaceB {}\n" );
+    File sig = createSourceFile( "example/Sig.gs",
+                                 "package example\n" +
+                                 "abstract class Sig <P extends IfaceA & ClassA & IfaceB> {\n" +
+                                 "\n" +
+                                 "}");
+
+
+    // Initial compilation
+    CompileResult initialResult = compile( Collections.emptyList() );
+    assertTrue( "Initial compilation should succeed", initialResult.success );
+    String depFileContent = Files.readString( dependencyFile.toPath() ).trim();
+    String expectedDepFile =
+      "{\n" +
+      "  \"version\": \"" + DEPENDENCY_VERSION + "\",\n" +
+      "  \"consumers\": {\n" +
+      "    \"example.ClassA\": [\n" +
+      "      \"example.Sig\"\n" +
+      "    ],\n" +
+      "    \"example.IfaceA\": [\n" +
+      "      \"example.Sig\"\n" +
+      "    ],\n" +
+      "    \"example.IfaceB\": [\n" +
+      "      \"example.Sig\"\n" +
+      "    ],\n" +
+      "    \"example.Sig\": []\n" +
+      "  }\n" +
+      "}";
+    assertEquals("Dep file should match the expected one", expectedDepFile, depFileContent );
+  }
+
+  @Test
   public void testSourceFileDeletionOnTypeRemoval() throws Exception
   {
     // Test that both .class and source files are deleted from output when types are removed


### PR DESCRIPTION
According to the JVM specification, generic class signatures should have TypeParameters with a ClassBound type followed by InterfaceBound types.

```
ClassSignature:
    [TypeParameters] SuperclassSignature {SuperinterfaceSignature}
TypeParameters:
    < TypeParameter {TypeParameter} >
TypeParameter:
    Identifier ClassBound {InterfaceBound}
```

The compiler was not making this guarantee, and so subsequent reads of those signatures via a SignatureReader would throw StringIndexOutOfBoundsExceptions

For example:
```
 java.lang.StringIndexOutOfBoundsException: begin 37, end -1, length 104
	at java.base/java.lang.String.checkBoundsBeginEnd(String.java:3319)
	at java.base/java.lang.String.substring(String.java:1874)
	at gw.internal.ext.org.objectweb.asm.signature.SignatureReader.accept(SignatureReader.java:80)
	at gw.internal.gosu.incremental.DependenciesClassVisitor.maybeAddClassTypesFromSignature(DependenciesClassVisitor.java:111)
	at gw.internal.gosu.incremental.DependenciesClassVisitor.visit(DependenciesClassVisitor.java:72)
	at gw.internal.ext.org.objectweb.asm.ClassReader.accept(ClassReader.java:570)
	at gw.internal.ext.org.objectweb.asm.ClassReader.accept(ClassReader.java:425)
	at gw.internal.gosu.incremental.IncrementalCompilationManager.trackDependencies(IncrementalCompilationManager.java:83)
```