### PR TITLE
Make gosuc class file output independent of source file order

### DIFF
--- a/gosu-core-api/src/main/java/gw/lang/parser/StandardCoercionManager.java
+++ b/gosu-core-api/src/main/java/gw/lang/parser/StandardCoercionManager.java
@@ -1265,6 +1265,24 @@ public class StandardCoercionManager extends BaseService implements ICoercionMan
     {
       return null;
     }
+    else if( typeToCoerceTo instanceof ITypeVariableArrayType )
+    {
+      return RuntimeCoercer.instance();
+    }
+    else if( typeToCoerceTo instanceof ITypeVariableType )
+    {
+      // Decided before the equals() test below on purpose. ITypeVariableType.equals() is not
+      // equality, it delegates to isAssignableFrom(), and type variable instances are not
+      // canonical -- the header is re-parsed per compile phase and a fresh instance is made each
+      // time (see the note on TypeVariableType.equals). Two instances of the *same* function's
+      // type variable can therefore compare unequal because their enclosing IFunctionType's
+      // param signatures differ, and which instance is reached depends on what was compiled
+      // first. Asking that question here made `x as T` compile to a null coercer in one source
+      // order and TypeVariableCoercer in another. Coercing to a type variable is what
+      // TypeVariableCoercer is for, and it is a no-op at runtime when the value is already
+      // assignable, so answer it directly instead.
+      return TypeVariableCoercer.instance();
+    }
     else if( typeToCoerceTo.equals( typeToCoerceFrom ) )
     {
       return null;
@@ -1272,14 +1290,6 @@ public class StandardCoercionManager extends BaseService implements ICoercionMan
     else if( typeToCoerceTo instanceof IErrorType || typeToCoerceFrom instanceof IErrorType )
     {
       return null;
-    }
-    else if( typeToCoerceTo instanceof ITypeVariableArrayType )
-    {
-      return RuntimeCoercer.instance();
-    }
-    else if( typeToCoerceTo instanceof ITypeVariableType )
-    {
-      return TypeVariableCoercer.instance();
     }
     else if( typeToCoerceTo.isAssignableFrom( typeToCoerceFrom ) && (!typeToCoerceFrom.isGenericType() || typeToCoerceFrom.isParameterizedType()) )
     {

--- a/gosu-core/src/main/java/gw/internal/gosu/ir/nodes/JavaClassIRType.java
+++ b/gosu-core/src/main/java/gw/internal/gosu/ir/nodes/JavaClassIRType.java
@@ -20,6 +20,7 @@ import gw.lang.reflect.java.IJavaType;
 import gw.util.GosuClassUtil;
 
 import gw.util.Array;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -221,20 +222,50 @@ public class JavaClassIRType implements IJavaClassIRType {
     if (otherType instanceof JavaClassIRType) {
       return _class.isAssignableFrom(((JavaClassIRType) otherType)._class);
     } else if (otherType instanceof GosuClassIRType) {
-      Set<? extends IType> allTypesInHierarchy = ((GosuClassIRType)otherType).getType().getAllTypesInHierarchy();
-      for (IType hierarchyType : allTypesInHierarchy) {
+      IType gosuType = ((GosuClassIRType)otherType).getType();
+      for (IType hierarchyType : gosuType.getAllTypesInHierarchy()) {
         IJavaClassInfo javaClassForType = resolveJavaClassForType(hierarchyType);
         if (javaClassForType != null && javaClassForType.getName().equals(_class.getName())) {
           return true;
         }
       }
 
-      return false;
+      // Missing it above does not mean "not assignable". getAllTypesInHierarchy() is populated
+      // lazily, and when a Gosu class is compiled after its Gosu supertype it can come back
+      // holding only the Gosu links of the chain -- every Java ancestor absent -- even though the
+      // supertype chain itself resolves all the way down. Whether that happens depends on the
+      // order sources were compiled in, and a spurious false here makes the caller emit a
+      // checkcast that the same compile in a different order omits. Walking the chain resolves
+      // each link on demand, so it answers the same way regardless of what has been cached.
+      return isJavaAncestorOf(gosuType, new HashSet<IType>());
     } else if (otherType instanceof SyntheticIRType) {
       return _class.isAssignableFrom(TypeSystem.getJavaClassInfo(((SyntheticIRType) otherType).getSuperClass(), TypeSystem.getGlobalModule()));
     } else {
       return false;
     }
+  }
+
+  /**
+   * True if this IRType's Java class appears in {@code type}'s supertype/interface graph. Unlike
+   * getAllTypesInHierarchy() this walks the links directly, resolving each on demand.
+   */
+  private boolean isJavaAncestorOf( IType type, Set<IType> visited ) {
+    while( type != null && visited.add( type ) ) {
+      IJavaClassInfo javaClassForType = resolveJavaClassForType( type );
+      if( javaClassForType != null && javaClassForType.getName().equals( _class.getName() ) ) {
+        return true;
+      }
+      IType[] interfaces = type.getInterfaces();
+      if( interfaces != null ) {
+        for( IType iface : interfaces ) {
+          if( isJavaAncestorOf( iface, visited ) ) {
+            return true;
+          }
+        }
+      }
+      type = type.getSupertype();
+    }
+    return false;
   }
 
   private IJavaClassInfo resolveJavaClassForType( IType hierarchyType ) {

--- a/gosu-core/src/main/java/gw/internal/gosu/parser/TypeLord.java
+++ b/gosu-core/src/main/java/gw/internal/gosu/parser/TypeLord.java
@@ -1343,6 +1343,30 @@ public class TypeLord
 
   public static IType makeDefaultParameterizedType( IType type )
   {
+    return makeDefaultParameterizedType( type, new HashSet<IType>() );
+  }
+
+  /**
+   * Parameterize {@code type} with the bounding types of its type variables.
+   *
+   * <p>The bounds are themselves expanded to a fixpoint. Taking a bound as-is -- which is what
+   * this method used to do -- makes the depth of the resulting parameterization depend on
+   * whatever expansion state that bound happened to already be in, and that state is a function
+   * of the order in which sources were compiled. Given
+   * {@code class AccountContactsCoreResource<P extends AccountCoreResource>} where
+   * {@code AccountCoreResource<P extends AccountsCoreResource>} is generic in turn, the result
+   * was {@code AccountContactsCoreResource<AccountCoreResource>} when AccountCoreResource had
+   * not been expanded yet and {@code AccountContactsCoreResource<AccountCoreResource<AccountsCoreResource>>}
+   * when it had. Expanding the bound here makes the result a pure function of the declarations.
+   *
+   * @param expanding the types currently being expanded on this path, guarding against a bound
+   *                  that reaches back through the type being expanded. It is a path set, not an
+   *                  accumulating visited set: an entry is removed once its subtree is done, so
+   *                  that two sibling type arguments sharing a type both expand the same way
+   *                  rather than the second one collapsing to raw.
+   */
+  private static IType makeDefaultParameterizedType( IType type, Set<IType> expanding )
+  {
     if( type != null && !(type instanceof IGosuEnhancementInternal) &&
         !type.isParameterizedType() && type.isGenericType() )
     {
@@ -1351,24 +1375,39 @@ public class TypeLord
         return MetaType.DEFAULT_TYPE_TYPE.get();
       }
 
-      IType[] boundingTypes = new IType[type.getGenericTypeVariables().length];
-      for( int i = 0; i < boundingTypes.length; i++ )
-      {
-        boundingTypes[i] = type.getGenericTypeVariables()[i].getBoundingType();
-
-        IGenericTypeVariable typeVar = type.getGenericTypeVariables()[i];
-        if( TypeLord.isRecursiveType( typeVar.getTypeVariableDefinition().getType(), typeVar.getBoundingType() ) )
-        {
-          return type;
-        }
-      }
-
-      if( boundingTypes.length == 0 )
+      IGenericTypeVariable[] typeVars = type.getGenericTypeVariables();
+      if( typeVars.length == 0 )
       {
         return type;
       }
 
-      type = type.getParameterizedType( boundingTypes );
+      if( !expanding.add( type ) )
+      {
+        // A bound cycles back through this type e.g., class C<T extends D<C>>. Bail to the raw
+        // type, matching the isRecursiveType behavior below.
+        return type;
+      }
+
+      IType rawType = type;
+      try
+      {
+        IType[] boundingTypes = new IType[typeVars.length];
+        for( int i = 0; i < typeVars.length; i++ )
+        {
+          IGenericTypeVariable typeVar = typeVars[i];
+          if( TypeLord.isRecursiveType( typeVar.getTypeVariableDefinition().getType(), typeVar.getBoundingType() ) )
+          {
+            return rawType;
+          }
+          boundingTypes[i] = makeDefaultParameterizedType( typeVar.getBoundingType(), expanding );
+        }
+
+        type = type.getParameterizedType( boundingTypes );
+      }
+      finally
+      {
+        expanding.remove( rawType );
+      }
     }
     return type;
   }

--- a/gosu-test/src/test/java/gw/internal/gosu/ir/nodes/JavaClassIRTypeTest.java
+++ b/gosu-test/src/test/java/gw/internal/gosu/ir/nodes/JavaClassIRTypeTest.java
@@ -1,0 +1,202 @@
+package gw.internal.gosu.ir.nodes;
+
+import gw.internal.gosu.ir.transform.util.IRTypeResolver;
+import gw.internal.gosu.parser.IGosuClassInternal;
+import gw.lang.ir.IRType;
+import gw.lang.reflect.IType;
+import gw.lang.reflect.TypeSystem;
+import gw.lang.reflect.gs.IGosuObject;
+import gw.lang.reflect.java.IJavaType;
+import gw.test.TestClass;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import junit.framework.TestCase;
+
+/**
+ * Covers {@link JavaClassIRType#isAssignableFrom} when the operand is a Gosu class.
+ *
+ * <p>That answer decides whether {@code AbstractExpressionTransformer.maybeCast} emits a
+ * {@code checkcast} for a call argument. It used to be only a scan of the Gosu class's
+ * {@code getAllTypesInHierarchy()} for a Java ancestor by name, falling through to {@code false} on
+ * a miss. That set is populated lazily, and when a Gosu class is compiled after its Gosu supertype
+ * it can come back holding only the Gosu links -- every Java ancestor absent -- even though the
+ * supertype chain resolves all the way down. A miss therefore did not mean "not assignable", and
+ * whether the scan hit depended on compile order.
+ *
+ * <p>The fixture is a real Gosu-extends-Java hierarchy:
+ * {@code gw.test.TestClassGosuTest} (Gosu) -&gt; {@code gw.test.TestClass} (Java) -&gt;
+ * {@code junit.framework.TestCase} (Java), which also implements {@code IGosuObject}.
+ */
+public class JavaClassIRTypeTest extends TestClass
+{
+  private static final String GOSU_SUBCLASS = "gw.test.TestClassGosuTest";
+
+  private static IRType gosuSubclassIRType()
+  {
+    IType gosuType = TypeSystem.getByFullName( GOSU_SUBCLASS );
+    assertNotNull( "fixture " + GOSU_SUBCLASS + " must resolve", gosuType );
+    return IRTypeResolver.getDescriptor( gosuType );
+  }
+
+  private static IRType irTypeOf( Class<?> cls )
+  {
+    return IRTypeResolver.getDescriptor( TypeSystem.get( cls ) );
+  }
+
+  public void testJavaIRTypeIsAssignableFromAGosuSubclassOfIt()
+  {
+    assertTrue( GOSU_SUBCLASS + " directly extends TestClass, so it must be assignable to it",
+                irTypeOf( TestClass.class ).isAssignableFrom( gosuSubclassIRType() ) );
+  }
+
+  /**
+   * TestCase is reached only through the Java class in between. The deeper the ancestor, the more
+   * the old scan depended on how much of the hierarchy had been cached when the question was asked.
+   */
+  public void testJavaIRTypeIsAssignableFromAGosuSubclassThroughADeeperJavaAncestor()
+  {
+    assertTrue( "TestCase is a transitive Java ancestor of " + GOSU_SUBCLASS,
+                irTypeOf( TestCase.class ).isAssignableFrom( gosuSubclassIRType() ) );
+  }
+
+  /**
+   * The chain walk has to follow interfaces as well as supertypes, otherwise assignability to an
+   * interface a Gosu class picks up implicitly would regress.
+   */
+  public void testJavaInterfaceIRTypeIsAssignableFromAGosuClass()
+  {
+    assertTrue( "every Gosu class implements IGosuObject",
+                irTypeOf( IGosuObject.class ).isAssignableFrom( gosuSubclassIRType() ) );
+  }
+
+  /**
+   * The chain walk must not make everything assignable -- an unrelated Java type still has to come
+   * back false, otherwise casts that are genuinely required would be dropped and the verifier would
+   * reject the class.
+   */
+  public void testJavaIRTypeIsNotAssignableFromAnUnrelatedGosuType()
+  {
+    assertFalse( "String is not in the hierarchy of " + GOSU_SUBCLASS,
+                 irTypeOf( String.class ).isAssignableFrom( gosuSubclassIRType() ) );
+  }
+
+  /**
+   * The IRType answer must be true for every ancestor that is genuinely in the chain, however it is
+   * reached -- directly, transitively, or through a proxy class.
+   *
+   * <p>This deliberately does not assert that {@code IType.isAssignableFrom} agrees. It does not:
+   * for {@code IGosuObject}, which a Gosu class picks up as the proxy
+   * {@code _proxy_.gw.lang.reflect.gs.IGosuObject}, the type system reports false while the IRType
+   * walk unwraps the proxy and finds it. That divergence is part of why IType assignability could
+   * not be used to fix the order dependence -- it consults the same lazily-populated hierarchy that
+   * was incomplete in the first place.
+   */
+  public void testIRTypeReportsEveryReachableAncestorAssignable()
+  {
+    IRType gosuIR = gosuSubclassIRType();
+
+    for( Class<?> cls: new Class<?>[]{ TestClass.class, TestCase.class, IGosuObject.class, Object.class } )
+    {
+      assertTrue( "IRType must report " + cls.getName() + " assignable from " + GOSU_SUBCLASS,
+                  irTypeOf( cls ).isAssignableFrom( gosuIR ) );
+    }
+  }
+
+  /**
+   * <p>Every assertion above resolves the fixture from a settled type system, which hands back a fully
+   * populated {@code getAllTypesInHierarchy()} -- so the old cache scan finds its Java ancestor and they
+   * pass whether or not the bug is present. The incomplete-cache state cannot be reached that way.
+   *
+   * <p>So the state is supplied directly, via {@link #withGosuOnlyHierarchy}, and what gets asserted is
+   * the contract the fix establishes: <em>a miss in the hierarchy cache means "not resolved yet", not
+   * "not assignable"</em>. This fails when {@code isAssignableFrom} trusts the cache and passes when it
+   * falls back to walking supertypes and interfaces on demand.
+   */
+  public void testJavaIRTypeIsAssignableFromAGosuClassWhoseHierarchyCacheOmitsItsJavaAncestors()
+  {
+    IType real = TypeSystem.getByFullName( GOSU_SUBCLASS );
+    assertNotNull( "fixture " + GOSU_SUBCLASS + " must resolve", real );
+
+    IType incomplete = withGosuOnlyHierarchy( real );
+
+    // Precondition: the doubled hierarchy really is missing the Java ancestor being asked about,
+    // otherwise the assertion below would hold trivially.
+    for( IType hierarchyType : incomplete.getAllTypesInHierarchy() )
+    {
+      assertFalse( "the doubled hierarchy must not contain " + TestClass.class.getName() +
+                   " -- the test would pass vacuously",
+                   TestClass.class.getName().equals( hierarchyType.getName() ) );
+    }
+
+    assertTrue( "assignability must not depend on getAllTypesInHierarchy() being fully populated: " +
+                GOSU_SUBCLASS + " extends " + TestClass.class.getName() +
+                " whether or not the cached hierarchy says so",
+                irTypeOf( TestClass.class ).isAssignableFrom( GosuClassIRType.get( incomplete ) ) );
+  }
+
+  /**
+   * The other half of the contract: falling back to a supertype walk must not turn the answer into a
+   * blanket {@code true}. A genuinely unrelated Java type has to stay unassignable even when the cache
+   * is incomplete, or casts that are actually required would be dropped and the verifier would reject
+   * the class at load time.
+   */
+  public void testUnrelatedJavaTypeStaysUnassignableWhenTheHierarchyCacheIsIncomplete()
+  {
+    IType incomplete = withGosuOnlyHierarchy( TypeSystem.getByFullName( GOSU_SUBCLASS ) );
+
+    assertFalse( "String is not in the hierarchy of " + GOSU_SUBCLASS + ", incomplete cache or not",
+                 irTypeOf( String.class ).isAssignableFrom( GosuClassIRType.get( incomplete ) ) );
+  }
+
+  /**
+   * The real Gosu type with exactly one behaviour replaced: {@code getAllTypesInHierarchy()} returns only
+   * the Gosu links, every {@link IJavaType} dropped. That is the shape {@code GosuClass._setTypes} caches
+   * -- and caches permanently -- when the set is first computed before the Java ancestors have resolved;
+   * on {@code PolicyDocumentsCoreResource} it was measured at 4 Gosu-only entries against 11 complete.
+   *
+   * <p>Everything else, {@code getSupertype()} and {@code getInterfaces()} included, delegates to the real
+   * type, so the supertype walk the fix relies on sees a truthful hierarchy. Only the cache lies.
+   */
+  private static IType withGosuOnlyHierarchy( final IType real )
+  {
+    final Set<IType> gosuOnly = new LinkedHashSet<IType>();
+    for( IType hierarchyType : real.getAllTypesInHierarchy() )
+    {
+      if( !(hierarchyType instanceof IJavaType) )
+      {
+        gosuOnly.add( hierarchyType );
+      }
+    }
+
+    InvocationHandler handler = new InvocationHandler()
+    {
+      @Override
+      public Object invoke( Object proxy, Method method, Object[] args ) throws Throwable
+      {
+        if( method.getName().equals( "getAllTypesInHierarchy" ) && (args == null || args.length == 0) )
+        {
+          return gosuOnly;
+        }
+        try
+        {
+          return method.invoke( real, args );
+        }
+        catch( InvocationTargetException e )
+        {
+          throw e.getCause();
+        }
+      }
+    };
+
+    // IGosuClassInternal is what GosuClassIRType.get() requires of its operand.
+    return (IType)Proxy.newProxyInstance( IGosuClassInternal.class.getClassLoader(),
+                                          new Class<?>[]{ IGosuClassInternal.class },
+                                          handler );
+  }
+}

--- a/gosu-test/src/test/java/gw/internal/gosu/parser/StandardCoercionManagerTest.java
+++ b/gosu-test/src/test/java/gw/internal/gosu/parser/StandardCoercionManagerTest.java
@@ -6,10 +6,13 @@ package gw.internal.gosu.parser;
 
 import gw.config.CommonServices;
 import gw.lang.parser.StandardCoercionManager;
+import gw.lang.parser.coercers.TypeVariableCoercer;
 import gw.lang.parser.exceptions.ParseResultsException;
 import gw.lang.reflect.IType;
+import gw.lang.reflect.ITypeVariableType;
 import gw.lang.reflect.ReflectUtil;
 import gw.lang.reflect.TypeSystem;
+import gw.lang.reflect.gs.IGenericTypeVariable;
 import gw.lang.reflect.gs.IGosuObject;
 import gw.lang.reflect.java.JavaTypes;
 import gw.test.TestClass;
@@ -20,6 +23,7 @@ import junit.framework.Assert;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 
@@ -576,4 +580,78 @@ public class StandardCoercionManagerTest extends TestClass
     }
   }
 
+  //=======================================================
+  // Coercing to a type variable (order-dependence regression)
+  //=======================================================
+
+  /** The {@code E} of {@code java.util.List<E>}, as an {@link ITypeVariableType}. */
+  private static IType listTypeVariable()
+  {
+    IType typeVar = JavaTypes.LIST().getGenericTypeVariables()[0].getTypeVariableDefinition().getType();
+    assertTrue( "expected a type variable type, got " + typeVar.getClass().getName(),
+                typeVar instanceof ITypeVariableType );
+    return typeVar;
+  }
+
+  /**
+   * Baseline: coercing to a type variable resolves to {@link TypeVariableCoercer}.
+   */
+  public void testCoercingToATypeVariableResolvesToTypeVariableCoercer()
+  {
+    assertSame( TypeVariableCoercer.instance(),
+                CommonServices.getCoercionManager().resolveCoercerStatically( listTypeVariable(), JavaTypes.STRING() ) );
+  }
+
+  /**
+   * <p>{@code TypeVariableType.equals} concedes the reason in its own javadoc -- "By all rights type
+   * variable types should have identity equality. That's not the case right now ... We compile in
+   * multiple phases (header, decl, def). Each phase recompiles the header, including type vars. Each
+   * time a new type var type is created for the type var definition."
+   *
+   * <p>Two separately constructed instances of {@code List}'s {@code E} reproduce that without needing a
+   * compile: not identical, so the identity fast path cannot answer, but {@code equals()} reports them
+   * interchangeable -- so whichever of {@code equals()} and the {@code ITypeVariableType} check runs
+   * first decides the result.
+   */
+  public void testCoercingBetweenTwoNonCanonicalInstancesOfTheSameTypeVariableResolvesToTypeVariableCoercer()
+  {
+    IType listType = JavaTypes.LIST();
+    IGenericTypeVariable typeVar = listType.getGenericTypeVariables()[0];
+
+    IType first = new TypeVariableType( listType, typeVar );
+    IType second = new TypeVariableType( listType, typeVar );
+
+    // Preconditions. Without both of these the assertion below would hold whatever the branch order is,
+    // and the test would pass vacuously.
+    assertNotSame( "the two instances must be distinct, or the identity fast path answers before either" +
+                   " branch is reached", first, second );
+    assertTrue( "equals() must report the two instances interchangeable, or the equals() test falls" +
+                " through and the branch order stops mattering", first.equals( second ) );
+
+    assertSame( "coercing between two instances of the same type variable must still yield a coercer:" +
+                " the choice must not be routed through ITypeVariableType.equals()",
+                TypeVariableCoercer.instance(),
+                CommonServices.getCoercionManager().resolveCoercerStatically( first, second ) );
+  }
+
+
+  public void testCoercingToATypeVariableFromACompoundContainingItResolvesToTypeVariableCoercer()
+  {
+    IType typeVar = listTypeVariable();
+    IType compound = CompoundType.get( typeVar, TypeSystem.get( Date.class ) );
+
+    assertSame( "T & Date -> T must not depend on ITypeVariableType.equals()",
+                TypeVariableCoercer.instance(),
+                CommonServices.getCoercionManager().resolveCoercerStatically( typeVar, compound ) );
+  }
+
+  /**
+   * The identity fast path is checked before the type variable branch and must still win, so a
+   * genuinely no-op coercion does not start emitting a coercer call.
+   */
+  public void testCoercingATypeVariableToItselfNeedsNoCoercer()
+  {
+    IType typeVar = listTypeVariable();
+    assertNull( CommonServices.getCoercionManager().resolveCoercerStatically( typeVar, typeVar ) );
+  }
 }

--- a/gosu-test/src/test/java/gw/internal/gosu/parser/TypeLordTest.java
+++ b/gosu-test/src/test/java/gw/internal/gosu/parser/TypeLordTest.java
@@ -66,6 +66,22 @@ public class TypeLordTest extends TestClass
   class GenRec extends GenA<GenRec>{}
 
   //=======================================================
+  // Generic classes whose type-variable bounds are themselves generic.
+  //=======================================================
+  static class BndLeaf{}
+  static class BndMid<T extends BndLeaf>{}
+  @SuppressWarnings("rawtypes")
+  static class BndOuter<T extends BndMid>{}
+  @SuppressWarnings("rawtypes")
+  static class BndTwoArg<A extends BndMid, B extends BndMid>{}
+  // Bounds that reference each other, so expanding them to a fixpoint has to terminate.
+  @SuppressWarnings("rawtypes")
+  static class BndMutA<T extends BndMutB>{}
+  @SuppressWarnings("rawtypes")
+  static class BndMutB<T extends BndMutA>{}
+  static class BndSelf<T extends BndSelf<T>>{}
+
+  //=======================================================
   // Generic interfaces and friends
   //=======================================================
   interface IGenA1<T>{}
@@ -423,6 +439,86 @@ public class TypeLordTest extends TestClass
     IType pureList = JavaTypes.LIST();
     IType listOfString = pureList.getParameterizedType(JavaTypes.STRING());
     assertEquals(JavaTypes.LIST().getParameterizedType(JavaTypes.OBJECT()), TypeLord.findLeastUpperBound(Arrays.asList(pureList, listOfString)));
+  }
+
+  //=======================================================
+  // makeDefaultParameterizedType expands bounds to a fixpoint
+  //=======================================================
+
+  /**
+   * {@code BndOuter<T extends BndMid>} where {@code BndMid<T extends BndLeaf>} is generic in
+   * turn. Adopting the bound as-is -- which is what makeDefaultParameterizedType used to do --
+   * yields {@code BndOuter<BndMid>} when BndMid had not been expanded yet and
+   * {@code BndOuter<BndMid<BndLeaf>>} when it had, so the depth of the result depended on the
+   * order sources happened to be compiled in.
+   */
+  public void testDefaultParameterizationExpandsAGenericBoundInsteadOfLeavingItRaw()
+  {
+    IType def = TypeLord.makeDefaultParameterizedType( TypeSystem.get( BndOuter.class ) );
+
+    assertTrue( def.isParameterizedType() );
+    IType arg = def.getTypeParameters()[0];
+    assertEquals( TypeSystem.get( BndMid.class ), TypeLord.getPureGenericType( arg ) );
+    assertTrue( "the bound BndMid is itself generic and must not be left raw, but was: " + arg.getName(),
+                arg.isParameterizedType() );
+    assertEquals( TypeSystem.get( BndLeaf.class ), arg.getTypeParameters()[0] );
+  }
+
+  /**
+   * The invariant that makes the result a pure function of the declarations rather than of
+   * compile order: every type argument of a default parameterization is itself already in
+   * default-parameterized form, so expanding it again is a no-op.
+   */
+  public void testDefaultParameterizationIsClosedOverItsTypeArguments()
+  {
+    IType def = TypeLord.makeDefaultParameterizedType( TypeSystem.get( BndOuter.class ) );
+    for( IType arg: def.getTypeParameters() )
+    {
+      assertEquals( "type argument " + arg.getName() + " is not itself in default-parameterized form",
+                    arg, TypeLord.makeDefaultParameterizedType( arg ) );
+    }
+  }
+
+  /**
+   * {@code BndTwoArg<A extends BndMid, B extends BndMid>} -- both arguments must expand the
+   * same way. The cycle guard is a path set rather than an accumulating visited set precisely
+   * so that this holds: with the latter the second occurrence of BndMid would be treated as
+   * already seen and collapse to raw, which would just relocate the order dependence.
+   */
+  public void testSiblingTypeArgumentsSharingABoundExpandIdentically()
+  {
+    IType def = TypeLord.makeDefaultParameterizedType( TypeSystem.get( BndTwoArg.class ) );
+
+    IType[] args = def.getTypeParameters();
+    assertEquals( 2, args.length );
+    assertTrue( "expected the shared bound to be expanded, but got: " + args[0].getName(),
+                args[0].isParameterizedType() );
+    assertEquals( args[0], args[1] );
+  }
+
+  /**
+   * {@code BndMutA<T extends BndMutB>} and {@code BndMutB<T extends BndMutA>}. Expanding bounds
+   * to a fixpoint has to stop somewhere; the type that closes the cycle is left raw. Reaching
+   * the assertions at all is most of what this test checks.
+   */
+  public void testMutuallyRecursiveBoundsTerminate()
+  {
+    IType a = TypeLord.makeDefaultParameterizedType( TypeSystem.get( BndMutA.class ) );
+    IType b = TypeLord.makeDefaultParameterizedType( TypeSystem.get( BndMutB.class ) );
+
+    assertEquals( TypeSystem.get( BndMutA.class ), TypeLord.getPureGenericType( a ) );
+    assertEquals( TypeSystem.get( BndMutB.class ), TypeLord.getPureGenericType( b ) );
+  }
+
+  /**
+   * {@code BndSelf<T extends BndSelf<T>>} still bails out to the raw type through
+   * isRecursiveType. That check is unchanged by the fixpoint expansion, only moved ahead of
+   * the recursive call so it guards it.
+   */
+  public void testSelfRecursiveBoundIsStillLeftRaw()
+  {
+    IType self = TypeSystem.get( BndSelf.class );
+    assertEquals( self, TypeLord.makeDefaultParameterizedType( self ) );
   }
 
   public List<? extends String> returnsListOfString()


### PR DESCRIPTION
Compiling a big application twice from an identical baseline, varying only the order in which source files are handed to the compile loop, produced 8 differing class files out of 9820 and a differing dependency file. Output was deterministic for a given ordering, so file order was the only variable. Neither ordering was "correct" - sorting did not introduce a defect, it exposed pre-existing nondeterminism in three separate places.

TypeLord.makeDefaultParameterizedType
-------------------------------------
Default type-argument expansion took each type variable's getBoundingType() as it found it, so the depth of the result depended on whatever expansion state that bound happened to already be in - and that state is a function of compile order. Given class AccountContactsCoreResource<P extends AccountCoreResource> where AccountCoreResource<P extends AccountsCoreResource> is generic in turn, the result was AccountContactsCoreResource<AccountCoreResource> if the bound had not been expanded yet and
AccountContactsCoreResource<AccountCoreResource<AccountsCoreResource>> if it had.

Bounds are now expanded to a fixpoint. The public single-argument signature is unchanged and delegates to a private overload carrying a path set. The set is a path set rather than an accumulating visited set, unwound in a finally once a subtree is done, so two sibling type arguments sharing a type expand identically instead of the second collapsing to raw. A bound that cycles back through the type being expanded bails to the raw type, matching the existing isRecursiveType behaviour, which now guards the recursive call rather than following it. The empty-type-variable early return moved ahead of the loop.

This fixes the generic Signature attribute depth on three classes and the reified IType literal chains on two more. It also makes the dependency file order-insensitive without any change to the dependency tracker, because the type-literal pass records resolved ITypes and so inherited the same expansion.

JavaClassIRType.isAssignableFrom
--------------------------------
The Gosu-operand branch scanned getAllTypesInHierarchy() for a Java ancestor by name and returned false on a miss. That set is populated lazily and then cached for the life of the type, so compiling a Gosu class after its Gosu supertype can leave it holding only the Gosu links with every Java ancestor absent, even though the supertype chain itself resolves all the way down. A miss therefore meant "not resolved yet", not "not assignable", and a spurious false makes AbstractExpressionTransformer.maybeCast emit a checkcast on a call argument that the same compile in a different order omits.

The scan is kept as a fast path. On a miss it now walks the supertype and interface links directly via a new isJavaAncestorOf helper, resolving each link on demand, visited-set guarded for cycle safety. This can only turn false into true, and only when the Java class genuinely sits in the chain.

StandardCoercionManager.resolveCoercerStatically
------------------------------------------------
Both type-variable branches - ITypeVariableType and ITypeVariableArrayType - now precede the equals() and IErrorType tests. ITypeVariableType.equals() is not equality: it delegates to isAssignableFrom(), and type variable instances are not canonical, because the header is re-parsed once per compile phase and a fresh instance is minted each time. Two instances of the same function's type variable can therefore compare unequal because their enclosing IFunctionType param signatures differ, and which instance is reached depends on what was compiled first. Routing the decision through that question made `item as T`, on a value narrowed to `T & Date`, compile to a null coercer in one source order and to TypeVariableCoercer in another.

The typeToCoerceTo == typeToCoerceFrom identity fast path still precedes everything, so a genuine no-op coercion does not start emitting a coercer call. Coercing to a type variable is what TypeVariableCoercer is for, and it is a runtime no-op when the value is already assignable, so this is the coercion-adding direction. One side effect of the reorder: coercing to a type variable from an IErrorType now yields the coercer rather than null. That path only arises after the compiler has already errored.

Result
------
Both orderings now produce byte-identical class output and byte-identical dependency files.

Tests
-----
Each of the three fixes was reverted in turn and the tests measured both ways, so every one has at least one test that fails without it:

  TypeLordTest                  3 of 5 fail when reverted
  StandardCoercionManagerTest   2 of 4
  JavaClassIRTypeTest           1 of 7

Two of these bugs live in cached or non-canonical state rather than in a computation, and that state is not reachable from a settled type system: a test that resolves a fixture and asks the question gets the correct answer and passes against the broken code. Those two construct the state instead - a Proxy that lies only about getAllTypesInHierarchy(), and two separately built instances of one type variable