### PR TITLE
Fix dependency edges dropped for parameterized type literals

### DIFF
--- a/gosu-core-api/src/main/java/gw/lang/gosuc/cli/CommandLineOptions.java
+++ b/gosu-core-api/src/main/java/gw/lang/gosuc/cli/CommandLineOptions.java
@@ -4,8 +4,6 @@ import gw.internal.ext.com.beust.jcommander.Parameter;
 import gw.internal.ext.com.beust.jcommander.validators.PositiveInteger;
 
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -163,9 +161,9 @@ public class CommandLineOptions
   {
     if( typeList == null || typeList.trim().isEmpty() )
     {
-      return Collections.emptySet();
+      return new LinkedHashSet<>();
     }
-    HashSet<String> types = new LinkedHashSet<>();
+    LinkedHashSet<String> types = new LinkedHashSet<>();
     for( String type : typeList.split( java.io.File.pathSeparator ) )
     {
       String trimmed = type.trim();
@@ -191,7 +189,7 @@ public class CommandLineOptions
   {
     if( _localJavaTypes == null || _localJavaTypes.trim().isEmpty() )
     {
-      return Collections.emptyList();
+      return new ArrayList<>();
     }
     List<String> types = new ArrayList<>();
     for( String type : _localJavaTypes.split( java.io.File.pathSeparator ) )

--- a/gosu-core-api/src/main/java/gw/lang/gosuc/simple/GosuCompiler.java
+++ b/gosu-core-api/src/main/java/gw/lang/gosuc/simple/GosuCompiler.java
@@ -136,6 +136,9 @@ public class GosuCompiler implements IGosuCompiler
     Set<String> changedTypes = options.getChangedTypes();
     Set<String> removedTypes = options.getRemovedTypes();
 
+    // changedTypes and removedTypes must be disjoint: filter out from removedTypes, types
+    // that are recorded as BOTH removed and changed
+    removedTypes.removeAll( changedTypes );
     // Calculate types that need recompilation (returns FQCNs)
     Set<String> typeFqcnsToCompile = _incrementalManager.calculateRecompilationSet(
       changedTypes, removedTypes );
@@ -145,7 +148,7 @@ public class GosuCompiler implements IGosuCompiler
     toDelete.addAll( typeFqcnsToCompile );
     // TODO: Non-transactional: deletion happens before the compiler runs. If compile then fails, the deleted
     // outputs are gone with no rollback. A future stash-and-restore step would close this gap.
-    deleteClassAndSourceFiles( toDelete, options.getDestDir(), options.isVerbose() );
+    deleteClassAndSourceFiles( toDelete, options.getDestDir() );
 
     Set<String> sourceFilesToCompile = new HashSet<>();
 
@@ -430,17 +433,16 @@ public class GosuCompiler implements IGosuCompiler
    *
    * @param fqcns   FQCNs whose outputs should be deleted
    * @param destDir output directory (e.g. {@code build/classes/gosu/main})
-   * @param verbose if true, log each deletion
    */
-  private void deleteClassAndSourceFiles( Set<String> fqcns, String destDir, boolean verbose )
+  private void deleteClassAndSourceFiles( Set<String> fqcns, String destDir )
   {
     if( !fqcns.isEmpty() && destDir != null && !destDir.isEmpty() )
     {
       File dest = new File( destDir );
       for( String fqcn : fqcns )
       {
-        deleteClassFile( fqcn, dest, verbose );
-        deleteSourceFile( fqcn, dest, verbose );
+        deleteIfPresent( classFileFor( dest, fqcn ) );
+        deleteSourceFile( fqcn, dest );
       }
     }
   }
@@ -457,41 +459,16 @@ public class GosuCompiler implements IGosuCompiler
   }
 
   /**
-   * Delete the .class file for the given type.
+   * Delete {@code file} if it is there, warning if the deletion itself fails.
    *
-   * @param fqcn      The fully-qualified class name of the type to clean up
-   * @param outputDir The output directory containing compiled .class files
-   * @param verbose   Whether to log deletion operations
+   * @param file the file to delete
    */
-  private void deleteClassFile( String fqcn, File outputDir, boolean verbose )
+  private static void deleteIfPresent( File file )
   {
-    File mainClassFile = classFileFor( outputDir, fqcn );
-
-    if( verbose )
+    // delete() also returns false for a file that was never there, so exists() is needed.
+    if( file.exists() && !file.delete() )
     {
-      System.out.println( "Attempting to delete class file for removed type: " + fqcn );
-      System.out.println( "  Output dir: " + outputDir );
-      System.out.println( "  Target file: " + mainClassFile );
-      System.out.println( "  File exists: " + mainClassFile.exists() );
-    }
-
-    if( mainClassFile.exists() )
-    {
-      if( mainClassFile.delete() )
-      {
-        if( verbose )
-        {
-          System.out.println( "Deleted stale class file: " + mainClassFile );
-        }
-      }
-      else
-      {
-        System.err.println( "Warning: Failed to delete class file: " + mainClassFile );
-      }
-    }
-    else if( verbose )
-    {
-      System.out.println( "Class file does not exist (may have already been deleted): " + mainClassFile );
+      System.err.println( "Warning: Failed to delete file: " + file );
     }
   }
 
@@ -501,49 +478,19 @@ public class GosuCompiler implements IGosuCompiler
    * <p>
    * Since there's no way to determine which extension a FQCN originally had
    * (could be .gs, .gr, .grs, .gst, .gsp, or .gsx), we attempt deletion for
-   * all known Gosu extensions. File.delete() is safe for non-existent files.
+   * all known Gosu extensions; the ones that aren't there are skipped.
    *
    * @param fqcn      The fully qualified name of the type
    * @param outputDir The output directory containing source files
-   * @param verbose   Whether to log deletion operations
    */
-  private void deleteSourceFile( String fqcn, File outputDir, boolean verbose )
-  {
-    // Use official list from GosuClassTypeLoader: .gs, .gsx, .gsp, .gst, .gr, .grs
-    String[] extensions = gw.lang.reflect.gs.GosuClassTypeLoader.ALL_EXTS;
-
-    for( String extension : extensions )
-    {
-      deleteSourceFile( fqcn, extension, outputDir, verbose );
-    }
-  }
-
-  /**
-   * Deletes a specific source file from the output directory.
-   *
-   * @param fqcn      The fully qualified name of the type
-   * @param extension The file extension (e.g., ".gs", ".gr", etc.)
-   * @param outputDir The output directory
-   * @param verbose   Whether to log deletion operations
-   */
-  private void deleteSourceFile( String fqcn, String extension, File outputDir, boolean verbose )
+  private static void deleteSourceFile( String fqcn, File outputDir )
   {
     String relativePath = fqcn.replace( '.', File.separatorChar );
-    File sourceFile = new File( outputDir, relativePath + extension );
 
-    if( sourceFile.exists() )
+    // Use official list from GosuClassTypeLoader: .gs, .gsx, .gsp, .gst, .gr, .grs
+    for( String extension : gw.lang.reflect.gs.GosuClassTypeLoader.ALL_EXTS )
     {
-      if( sourceFile.delete() )
-      {
-        if( verbose )
-        {
-          System.out.println( "Deleted stale source file: " + sourceFile );
-        }
-      }
-      else
-      {
-        System.err.println( "Warning: Failed to delete source file: " + sourceFile );
-      }
+      deleteIfPresent( new File( outputDir, relativePath + extension ) );
     }
   }
 

--- a/gosu-core/src/main/java/gw/internal/gosu/incremental/IncrementalCompilationManager.java
+++ b/gosu-core/src/main/java/gw/internal/gosu/incremental/IncrementalCompilationManager.java
@@ -89,8 +89,11 @@ public class IncrementalCompilationManager implements IIncrementalCompilationMan
    * {@code .class} filenames, with {@code $} as the separator between an enclosing
    * type and a nested one. For top-level types this is just the type's name.
    *
-   * <p>Defined as a structural recurrence on the enclosing-type chain:
+   * <p>Defined as a structural recurrence on the enclosing-type chain, over the type's
+   * <i>erasure</i>:
    * <ul>
+   *   <li>a parameterized type is first replaced by its generic type, so that no type
+   *       arguments reach the result;</li>
    *   <li>if {@code type} is top-level (no enclosing type), the result is
    *       {@code type.getName()};</li>
    *   <li>otherwise, the result is {@code getClassFileName(enclosing) + "$" +
@@ -101,15 +104,32 @@ public class IncrementalCompilationManager implements IIncrementalCompilationMan
    * <ul>
    *   <li>top-level: {@code example.Outer} -&gt; {@code "example.Outer"}</li>
    *   <li>member class: {@code example.Outer.Inner} -&gt; {@code "example.Outer$Inner"}</li>
+   *   <li>parameterized: {@code example.Outer.Inner<String>} -&gt;
+   *       {@code "example.Outer$Inner"}</li>
    *   <li>nested block: {@code Outer.AnonymouS__0.block_0_} -&gt;
    *       {@code "example.Outer$AnonymouS__0$block_0_"}</li>
    * </ul>
    * <p>
    * Used as the FQCN shape stored in the dep graph so dep-file keys match
    * {@code .class} artifacts.
+   *
+   * <p>The erasure step is what makes those keys usable. A key is matched against
+   * {@code .class} artifacts and against the FQCNs passed in {@code -changed-types}, and a
+   * parameterized name matches neither. Without it, {@code getRelativeName()} of a
+   * parameterized nested type carries its type arguments and the key came out as
+   * {@code "example.Outer$Inner<String>"}; {@link #shouldTrackType} accepted that, because
+   * {@link #getGosuFilePathFromFqcn} strips at the last {@code $} and resolves the enclosing
+   * class, so the edge was recorded under a key that could never fire. For a parameterized
+   * <i>top-level</i> type there is no {@code $} to strip, the lookup failed outright, and the
+   * edge was dropped without a trace -- silently losing dependencies for every type literal
+   * that resolved to a generic type.
    */
   private static String getClassFileName( IType type )
   {
+    if( type.isParameterizedType() )
+    {
+      type = type.getGenericType();
+    }
     IType enclosing = type.getEnclosingType();
     if( enclosing == null )
     {

--- a/gosu-core/src/main/java/gw/internal/gosu/incremental/incr_gosu_design.md
+++ b/gosu-core/src/main/java/gw/internal/gosu/incremental/incr_gosu_design.md
@@ -70,9 +70,9 @@ entire surface the Gradle plugin drives:
 | `-incremental` | `boolean _incremental` | Enables the incremental path. Absent ⇒ compile all sources (unchanged legacy behavior). |
 | `-dependency-file <path>` | `String _dependencyFile` | Path to the dependency file. **Default `.gosuc-deps.json`**; the plugin passes `build/tmp/gosuc-deps-{taskName}.json`. |
 | `-changed-types <fqcns>` | `String _changedTypes` | Path-separator-delimited FQCNs (Java **and** Gosu) whose source changed. Exposed as `Set<String> getChangedTypes()`. |
-| `-removed-types <fqcns>` | `String _removedTypes` | Path-separator-delimited FQCNs whose source was deleted. Exposed as `Set<String> getRemovedTypes()`. |
+| `-removed-types <fqcns>` | `String _removedTypes` | Path-separator-delimited FQCNs whose source was deleted. Exposed as `Set<String> getRemovedTypes()`. **May overlap `-changed-types` as supplied** — a source deleted and re-added inside one change window is reported as both — and the driver makes the two disjoint before use (§5). |
 | `-local-java-types <fqcns>` | `String _localJavaTypes` | Path-separator-delimited FQCNs of **same-module Java types** (the plugin populates this by scanning `build/classes/java/main`). Exposed as `List<String> getLocalJavaTypes()`. |
-| `-verbose` | `boolean _verbose` | Diagnostic logging throughout the incremental path. |
+| `-verbose` | `boolean _verbose` | Diagnostic logging along the incremental path. Not every step honors it: stale-output deletion (§8) reports failures unconditionally and logs nothing otherwise. |
 
 Delimiter is `File.pathSeparator` throughout; empty/blank strings parse to empty
 collections.
@@ -117,8 +117,16 @@ everything (this is the pre-existing behavior, now factored into a helper).
    passing the dep-file path, source roots, `-local-java-types`, the full source
    list, and the verbose flag. Construction **loads** the existing dep file into the
    in-memory `typeDependencies` graph and builds the `fqcn → source path` index.
-3. **Compute the recompile set**:
+3. **Make the change sets disjoint, then compute the recompile set.** A type can be
+   reported as both changed and removed — a source deleted and re-added inside one
+   change window looks exactly like that — so `removedTypes.removeAll(changedTypes)`
+   runs first: if the source is present now, "changed" wins. Then
    `typeFqcnsToCompile = calculateRecompilationSet(changedTypes, removedTypes)` (§7).
+
+   The filter is applied once and both consumers see the filtered set —
+   `calculateRecompilationSet` here, and `effectivelyRemoved` at step 8. Without it a
+   re-added type would be excluded from `toRecompile` (§7), have its outputs deleted at
+   step 4 and never regenerated, *and* lose its producer entry at step 8.
 4. **Delete stale outputs** for `removedTypes ∪ typeFqcnsToCompile` **before**
    compiling (`deleteClassAndSourceFiles`, §8). This is explicitly
    **non-transactional** — a code TODO notes that a compile failure after deletion
@@ -290,7 +298,10 @@ Key properties:
   excluded from `toRecompile` — gosuc cannot recompile Java sources; `compileJava`
   already did.
 - **Removed types cascade but aren't compiled.** Their source is gone, so they are
-  excluded from `toRecompile`, but their downstream consumers still cascade.
+  excluded from `toRecompile`, but their downstream consumers still cascade. This rests
+  on `removedTypes` being accurate: a type still present on disk but reported removed
+  would be skipped by the `X ∉ removedTypes` test and never rebuilt, which is why the
+  driver subtracts `changedTypes` from `removedTypes` before calling in (§5).
 - **Invariant that keeps the lookup null-safe.** `typeDependencies[X]` is iterated
   without a null guard. This is safe because every compiled type is registered as a
   key (§6.1), so every consumer FQCN reachable in the graph is also a key; seeds are
@@ -307,8 +318,7 @@ typeFqcnsToCompile`:
 - the **source copy** — gosuc packages `.gs*` sources alongside `.class` files in the
   output dir, so any stale source copy is removed too. Because the original
   extension isn't recoverable from an FQCN, deletion is attempted for **all** known
-  Gosu extensions (`.gs .gsx .gsp .gst .gr .grs`); `File.delete()` is a no-op on
-  absent files.
+  Gosu extensions (`.gs .gsx .gsp .gst .gr .grs`); those not present are skipped.
 
 There is **no per-FQCN `$*.class` glob**. Nested compiled units are cleaned because
 the BFS already pulls every nested FQCN into `typeFqcnsToCompile` (bidirectional
@@ -385,6 +395,25 @@ at construction from the full source list, keyed on outermost FQCN). On a miss i
 strips trailing `$…` segments and retries, so `example.Outer$Inner` and
 `example.Outer$Anon__0$block_0_` both resolve to `Outer.gs`. Returns `null` for
 anything not a known local Gosu source.
+
+**Producer keys are erased FQCNs.** `getClassFileName` replaces a parameterized type
+with its generic type before walking the enclosing-type chain, so no key ever carries
+type arguments. A key is only ever matched against `.class` artifacts and against the
+FQCNs in `-changed-types`, and a parameterized name matches neither — but the two
+failure modes differ, and the `$`-stripping above is what makes one of them silent:
+
+- a parameterized **nested** type, `example.Outer$Inner<String>`, has a `$`, so the
+  retry loop strips it and resolves `example.Outer`. `shouldTrackType` returns *true*
+  and the edge is recorded under a key that can never fire.
+- a parameterized **top-level** type, `example.Box<example.Leaf>`, has no `$` to strip.
+  The lookup fails, `shouldTrackType` returns false, and the edge is dropped with no
+  trace — losing dependencies for every type literal that resolves to a generic type.
+
+Erasing at the top of `getClassFileName` covers both, and because the erasure precedes
+the recursion it applies to a parameterized *enclosing* type as well. It is also the
+only step needed: a parameterized type is itself an `IJavaType`/`IGosuClass`, so it
+reaches `getClassFileName` on its own and no separate descent into its generic type is
+required to record the link.
 
 Source roots and candidate paths are canonicalized (`toAbsolutePath().normalize()`)
 so lookups don't depend on how the caller spelled a path. `buildGosuFqcnToSourcePath`

--- a/gosu-test/src/test/java/gw/internal/gosu/incremental/IncrementalCompilationEndToEndIT.java
+++ b/gosu-test/src/test/java/gw/internal/gosu/incremental/IncrementalCompilationEndToEndIT.java
@@ -405,6 +405,87 @@ public class IncrementalCompilationEndToEndIT
   }
 
   @Test
+  public void testIncrementalCompilationWithDeletedAndReAddedFile() throws Exception
+  {
+    // Create files with dependencies
+    File util = createSourceFile( "example/StringUtil.gs",
+                                  "package example\n" +
+                                  "\n" +
+                                  "class StringUtil {\n" +
+                                  "  static function capitalize(s : String) : String {\n" +
+                                  "    return s?.substring(0, 1).toUpperCase() + s?.substring(1)\n" +
+                                  "  }\n" +
+                                  "}"
+    );
+
+    File consumer = createSourceFile( "example/Consumer.gs",
+                                       "package example\n" +
+                                       "\n" +
+                                       "class Consumer {\n" +
+                                       "  function formatName(name : String) : String {\n" +
+                                       "    return StringUtil.capitalize(name)\n" +
+                                       "  }\n" +
+                                       "}"
+    );
+
+
+
+    // Initial compilation
+    CompileResult initialResult = compile( Collections.emptyList() );
+    assertTrue( "Initial compilation should succeed", initialResult.success );
+
+    String depFileContent = Files.readString( dependencyFile.toPath() ).trim();
+    String expectedDepFile =
+      "{\n" +
+      "  \"version\": \"" + DEPENDENCY_VERSION + "\",\n" +
+      "  \"consumers\": {\n" +
+      "    \"example.Consumer\": [],\n" +
+      "    \"example.StringUtil\": [\n" +
+      "      \"example.Consumer\"\n" +
+      "    ]\n" +
+      "  }\n" +
+      "}";
+    assertEquals("Dep file should match the expected one", expectedDepFile, depFileContent );
+
+    Map<String, FileTime> initialTimestamps = recordTimestamps();
+    Thread.sleep( SLEEP_MS );
+
+    // Delete StringUtil
+    Files.delete( util.toPath() );
+    Path utilClassFile = outputDir.resolve( "example/StringUtil.class" );
+    assertTrue( "StringUtil.class should exist before the incremental compile", Files.exists( utilClassFile ) );
+
+    util = createSourceFile( "example/StringUtil.gs",
+                             "package example\n" +
+                             "\n" +
+                             "class StringUtil {\n" +
+                             "  static function foo(s : String) : String { return \"foo\" }\n" +
+                             "  static function capitalize(s : String) : String {\n" +
+                             "    return s?.substring(0, 1).toUpperCase() + s?.substring(1)\n" +
+                             "  }\n" +
+                             "}"
+    );
+
+    // Incremental compilation with same deleted/changed file
+    CompileResult incrementalResult = compileWithDeleted(
+      Arrays.asList( util ),
+      Arrays.asList( util )
+    );
+
+    depFileContent = Files.readString( dependencyFile.toPath() ).trim();
+    assertEquals("Dep file should match the expected one", expectedDepFile, depFileContent );
+
+    Map<String, FileTime> afterTimestamps = recordTimestamps();
+    assertTrue( "StringUtil.class should be regenerated", Files.exists( utilClassFile ) );
+
+    assertTrue( "StringUtil should be recompiled",
+                afterTimestamps.get( "StringUtil.class" ).toMillis() > initialTimestamps.get( "StringUtil.class" ).toMillis() );
+    assertTrue( "Consumer should be recompiled",
+                afterTimestamps.get( "Consumer.class" ).toMillis() > initialTimestamps.get( "Consumer.class" ).toMillis() );
+    assertEquals( "Should compile only 2 files", 2, incrementalResult.filesCompiled );
+  }
+
+  @Test
   public void testGenericSignatureAsmVisitorParsing() throws Exception
   {
     File zclassA = createSourceFile( "example/zClassA.gs",
@@ -2318,6 +2399,167 @@ public class IncrementalCompilationEndToEndIT
   }
 
   @Test
+  public void testTypeLiteralOfNestedParameterizedTypeRecordsEdgeForEveryLinkNotJustTheLeaf() throws Exception
+  {
+    createSourceFile( "example/Leaf.gs",
+                      "package example\n" +
+                      "\n" +
+                      "class Leaf {\n" +
+                      "}"
+    );
+
+    createSourceFile( "example/Middle.gs",
+                      "package example\n" +
+                      "\n" +
+                      "class Middle<T extends Leaf> {\n" +
+                      "}"
+    );
+
+    createSourceFile( "example/Box.gs",
+                      "package example\n" +
+                      "\n" +
+                      "class Box<T extends Middle<Leaf>> {\n" +
+                      "}"
+    );
+
+    // The only type named in the body is `Box`; it resolves to Box<Middle<Leaf>>.
+    createSourceFile( "example/Consumer.gs",
+                      "package example\n" +
+                      "\n" +
+                      "uses gw.lang.reflect.IType\n" +
+                      "\n" +
+                      "class Consumer {\n" +
+                      "  function typeLiteralAsValue() : IType {\n" +
+                      "    return Box\n" +
+                      "  }\n" +
+                      "}"
+    );
+
+    CompileResult result = compile( Collections.emptyList() );
+    assertTrue( "Initial compilation should succeed: " + result.error, result.success );
+
+    // Every link of the chain Box<Middle<Leaf>> must record Consumer as a consumer.
+    String actualDeps = Files.readString( dependencyFile.toPath() ).trim();
+    String expectedDeps =
+      "{\n" +
+      "  \"version\": \"" + DEPENDENCY_VERSION + "\",\n" +
+      "  \"consumers\": {\n" +
+      "    \"example.Box\": [\n" +
+      "      \"example.Consumer\"\n" +
+      "    ],\n" +
+      "    \"example.Consumer\": [],\n" +
+      "    \"example.Leaf\": [\n" +
+      "      \"example.Box\",\n" +
+      "      \"example.Consumer\",\n" +
+      "      \"example.Middle\"\n" +
+      "    ],\n" +
+      "    \"example.Middle\": [\n" +
+      "      \"example.Box\",\n" +
+      "      \"example.Consumer\"\n" +
+      "    ]\n" +
+      "  }\n" +
+      "}";
+    assertEquals( "A type literal resolving to Box<Middle<Leaf>> must record a dep edge for " +
+                  "every link of the chain, not just the innermost non-parameterized one",
+                  expectedDeps, actualDeps );
+
+
+    Map<String, FileTime> beforeLeafChange = recordTimestamps();
+    Thread.sleep( SLEEP_MS );
+
+    modifySourceFile( new File( srcDir.toFile(), "example/Leaf.gs" ),
+                      "class Leaf {\n",
+                      "class Leaf {\n  var _marker : int = 7\n" );
+
+    CompileResult afterLeafChange = compile(
+      Arrays.asList( new File( srcDir.toFile(), "example/Leaf.gs" ) ) );
+    assertTrue( "Compilation after the Leaf change should succeed: " + afterLeafChange.error,
+                afterLeafChange.success );
+
+    Map<String, FileTime> leafTimestamps = recordTimestamps();
+    assertTrue( "Consumer should be recompiled when Leaf changes",
+                leafTimestamps.get( "Consumer.class" ).toMillis() >
+                beforeLeafChange.get( "Consumer.class" ).toMillis() );
+
+    assertTrue( "Box should be recompiled when Leaf changes",
+                leafTimestamps.get( "Box.class" ).toMillis() >
+                beforeLeafChange.get( "Box.class" ).toMillis() );
+
+    assertTrue( "Middle should be recompiled when Leaf changes",
+                leafTimestamps.get( "Middle.class" ).toMillis() >
+                beforeLeafChange.get( "Middle.class" ).toMillis() );
+
+    Map<String, FileTime> beforeBoxChange = recordTimestamps();
+    Thread.sleep( SLEEP_MS );
+
+    modifySourceFile( new File( srcDir.toFile(), "example/Box.gs" ),
+                      "class Box<T extends Middle<Leaf>> {",
+                      "class Box<T extends Leaf> {" );
+
+    CompileResult afterBoxChange = compile(
+      Arrays.asList( new File( srcDir.toFile(), "example/Box.gs" ) ) );
+    assertTrue( "Compilation after the Box change should succeed: " + afterBoxChange.error,
+                afterBoxChange.success );
+
+    Map<String, FileTime> boxTimestamps = recordTimestamps();
+    assertTrue( "Consumer should be recompiled when Box change",
+                boxTimestamps.get( "Consumer.class" ).toMillis() >
+                beforeBoxChange.get( "Consumer.class" ).toMillis() );
+    assertTrue( "Middle should not be recompiled when Box change",
+                boxTimestamps.get( "Middle.class" ).toMillis() ==
+                beforeBoxChange.get( "Middle.class" ).toMillis() );
+    assertTrue( "Leaf should not be recompiled when Box change",
+                boxTimestamps.get( "Leaf.class" ).toMillis() ==
+                beforeBoxChange.get( "Leaf.class" ).toMillis() );
+  }
+
+  @Test
+  public void testDependencyFileNeverRecordsAParameterizedTypeNameAsAProducerKey() throws Exception
+  {
+    createSourceFile( "example/JunkLeaf.gs",
+                      "package example\n" +
+                      "\n" +
+                      "class JunkLeaf {\n" +
+                      "}"
+    );
+
+    createSourceFile( "example/JunkOuter.gs",
+                      "package example\n" +
+                      "\n" +
+                      "class JunkOuter {\n" +
+                      "  protected var _cell : Cell<JunkLeaf> = new Cell<JunkLeaf>()\n" +
+                      "\n" +
+                      "  protected static class Cell<V> {\n" +
+                      "    construct() {\n" +
+                      "    }\n" +
+                      "  }\n" +
+                      "}"
+    );
+
+    CompileResult result = compile( Collections.emptyList() );
+    assertTrue( "Initial compilation should succeed: " + result.error, result.success );
+
+    String actualDeps = Files.readString( dependencyFile.toPath() ).trim();
+    String expectedDeps =
+      "{\n" +
+      "  \"version\": \"" + DEPENDENCY_VERSION + "\",\n" +
+      "  \"consumers\": {\n" +
+      "    \"example.JunkLeaf\": [\n" +
+      "      \"example.JunkOuter\"\n" +
+      "    ],\n" +
+      "    \"example.JunkOuter\": [\n" +
+      "      \"example.JunkOuter$Cell\"\n" +
+      "    ],\n" +
+      "    \"example.JunkOuter$Cell\": [\n" +
+      "      \"example.JunkOuter\"\n" +
+      "    ]\n" +
+      "  }\n" +
+      "}";
+    assertEquals( "producer keys must be plain FQCNs -- no parameterized type names",
+                  expectedDeps, actualDeps );
+  }
+
+  @Test
   public void testIncrementalSaveMergesConsumersRatherThanReplacing() throws Exception
   {
     // Regression test: when only a subset of consumers are recompiled incrementally,
@@ -3181,9 +3423,8 @@ public class IncrementalCompilationEndToEndIT
   public void testSourceFilePresentInOutputAfterFullAndIncrementalCompile() throws Exception
   {
     // gosuc copies Gosu source files into the output directory alongside their
-    // .class files (the deleteClassFile path also deletes the source copy --
-    // see testSourceFileDeletionOnTypeRemoval). This test pins the inverse
-    // invariant: for sources that ARE compiled (initially and after modification),
+    // .class files. This test pins the inverse invariant:
+    // for sources that ARE compiled (initially and after modification),
     // the source copy in the output dir must be present and reflect the latest
     // content.
 


### PR DESCRIPTION
getClassFileName built the producer key from the type as given, so a parameterized name reached the key -- and a key carrying type arguments matches neither a .class artifact nor a -changed-types FQCN.

Also fixed: -changed-types and -removed-types could overlap, as they do when a source is deleted and re-added in one change window. The type stayed in removedTypes, so it was excluded from the recompile set, had its outputs deleted, was never regenerated, and lost its producer entry. The driver now subtracts changedTypes from removedTypes -- "changed" wins when the source is there now -- and both consumers see the filtered set;

Stale-output deletion drops its verbose tracing, which -verbose threaded four levels deep to reach. Only delete failures are reported now, and both delete paths share one helper.